### PR TITLE
refactor: allow the ability to configure the name of the standard oak…

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook SessionStart --agent claude",
+            "command": "oak-dev ci hook SessionStart --agent claude",
             "timeout": 60
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook UserPromptSubmit --agent claude",
+            "command": "oak-dev ci hook UserPromptSubmit --agent claude",
             "timeout": 60
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook PostToolUse --agent claude",
+            "command": "oak-dev ci hook PostToolUse --agent claude",
             "timeout": 60
           }
         ]
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook Stop --agent claude",
+            "command": "oak-dev ci hook Stop --agent claude",
             "timeout": 60
           }
         ]
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook SessionEnd --agent claude",
+            "command": "oak-dev ci hook SessionEnd --agent claude",
             "timeout": 60
           }
         ]
@@ -66,7 +66,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook PostToolUseFailure --agent claude",
+            "command": "oak-dev ci hook PostToolUseFailure --agent claude",
             "timeout": 60
           }
         ]
@@ -78,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook SubagentStart --agent claude",
+            "command": "oak-dev ci hook SubagentStart --agent claude",
             "timeout": 60
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook SubagentStop --agent claude",
+            "command": "oak-dev ci hook SubagentStop --agent claude",
             "timeout": 60
           }
         ]

--- a/.claude/skills/codebase-intelligence/SKILL.md
+++ b/.claude/skills/codebase-intelligence/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   in previous sessions, looking up past conversations or outcomes, querying
   session history, checking activity logs, browsing memories, running SQL
   against activities.db, or exploring patterns that grep would miss. Do NOT use
-  for storing memories — use oak_remember or oak ci remember instead.
+  for storing memories — use oak_remember or oak-dev ci remember instead.
 allowed-tools: Bash, Read
 user-invocable: true
 ---
@@ -23,20 +23,20 @@ Search, analyze, and query your codebase using semantic vector search, impact an
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 ```
 
 ### Impact analysis
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 ```
 
 ### Session and memory lookup
@@ -47,10 +47,10 @@ sqlite3 -readonly -header -column .oak/ci/activities.db \
   "SELECT id, agent, title, status, datetime(created_at_epoch, 'unixepoch', 'localtime') as started FROM sessions ORDER BY created_at_epoch DESC LIMIT 5;"
 
 # Search past decisions and learnings
-oak ci search "authentication refactor decision" --type memory
+oak-dev ci search "authentication refactor decision" --type memory
 
 # Browse memories by type
-oak ci memories --type decision
+oak-dev ci memories --type decision
 ```
 
 ### Database query
@@ -66,22 +66,22 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "SELECT count(*) FROM se
 
 | Command | Purpose |
 |---------|---------|
-| `oak ci search "query" --type code` | Semantic vector search for code |
-| `oak ci search "query" --type memory` | Semantic search for memories |
-| `oak ci search "query" -n 20` | Broader search with more results |
-| `oak ci context "task" -f <file>` | Get context for current work |
-| `oak ci remember "observation"` | Store a memory (NOT via SQL) |
-| `oak ci memories --type gotcha` | Browse memories by type |
-| `oak ci sessions` | List session summaries |
-| `oak ci status` | Check daemon status |
+| `oak-dev ci search "query" --type code` | Semantic vector search for code |
+| `oak-dev ci search "query" --type memory` | Semantic search for memories |
+| `oak-dev ci search "query" -n 20` | Broader search with more results |
+| `oak-dev ci context "task" -f <file>` | Get context for current work |
+| `oak-dev ci remember "observation"` | Store a memory (NOT via SQL) |
+| `oak-dev ci memories --type gotcha` | Browse memories by type |
+| `oak-dev ci sessions` | List session summaries |
+| `oak-dev ci status` | Check daemon status |
 
 ### MCP tools
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
 
 ### Direct SQL
 
@@ -93,15 +93,15 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 
 | Need | Tool | Example |
 |------|------|---------|
-| Find similar implementations | `oak ci search --type code` | "retry with exponential backoff" |
-| Understand component relationships | `oak ci context` | "how auth middleware relates to session handling" |
-| Assess refactoring risk | `oak ci search --type code -n 20` | "PaymentProcessor error handling" |
-| Find past decisions/gotchas | `oak ci search --type memory` | "gotchas with auth changes" |
+| Find similar implementations | `oak-dev ci search --type code` | "retry with exponential backoff" |
+| Understand component relationships | `oak-dev ci context` | "how auth middleware relates to session handling" |
+| Assess refactoring risk | `oak-dev ci search --type code -n 20` | "PaymentProcessor error handling" |
+| Find past decisions/gotchas | `oak-dev ci search --type memory` | "gotchas with auth changes" |
 | Recall previous discussions | `sqlite3 -readonly` | `SELECT title, summary FROM sessions WHERE ...` |
-| Find what was done before | `oak ci memories` / `sqlite3` | "what did we decide about caching?" |
+| Find what was done before | `oak-dev ci memories` / `sqlite3` | "what did we decide about caching?" |
 | Query session history | `sqlite3 -readonly` | `SELECT * FROM sessions ORDER BY ...` |
 | Aggregate usage stats | `sqlite3 -readonly` | `SELECT agent_name, sum(cost_usd) FROM agent_runs ...` |
-| Run automated analysis | `oak ci agent run` | `oak ci agent run usage-report` |
+| Run automated analysis | `oak-dev ci agent run` | `oak-dev ci agent run usage-report` |
 
 ## Why Semantic Search Over Grep
 
@@ -217,10 +217,10 @@ ORDER BY next_run_at_epoch;
 For automated analysis that runs queries and produces reports:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.claude/skills/codebase-intelligence/references/analysis-playbooks.md
+++ b/.claude/skills/codebase-intelligence/references/analysis-playbooks.md
@@ -2,7 +2,7 @@
 
 Structured multi-query workflows for analyzing CI data. Each playbook is a sequence of queries that build on each other to answer a specific question.
 
-These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak ci agent run <task-name>`).
+These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak-dev ci agent run <task-name>`).
 
 ## Playbook 1: Usage & Cost Analysis
 
@@ -223,10 +223,10 @@ LIMIT 10;
 These playbooks can be run automatically via the analysis agent:
 
 ```bash
-oak ci agent run usage-report          # Playbook 1
-oak ci agent run productivity-report   # Playbook 2
-oak ci agent run codebase-activity-report  # Playbook 3
-oak ci agent run prompt-analysis       # Playbook 4
+oak-dev ci agent run usage-report          # Playbook 1
+oak-dev ci agent run productivity-report   # Playbook 2
+oak-dev ci agent run codebase-activity-report  # Playbook 3
+oak-dev ci agent run prompt-analysis       # Playbook 4
 ```
 
 Reports are written to `oak/insights/` and can be committed to git for team visibility.

--- a/.claude/skills/codebase-intelligence/references/finding-related-code.md
+++ b/.claude/skills/codebase-intelligence/references/finding-related-code.md
@@ -29,39 +29,39 @@ Use this workflow when:
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 
 # More results for broader exploration
-oak ci search "error handling and logging" --type code -n 20
+oak-dev ci search "error handling and logging" --type code -n 20
 ```
 
 ### Discover component relationships
 
 ```bash
 # Find code related to two concepts (relationship)
-oak ci search "how does AuthService interact with TokenManager"
+oak-dev ci search "how does AuthService interact with TokenManager"
 
 # Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 
 # Get context about a specific relationship
-oak ci context "relationship between UserService and PaymentProcessor"
+oak-dev ci context "relationship between UserService and PaymentProcessor"
 ```
 
 ### Get context for current work
 
 ```bash
 # Find code related to files you're editing
-oak ci context "similar implementations" -f src/services/user.py
+oak-dev ci context "similar implementations" -f src/services/user.py
 
 # Find related code for a specific task
-oak ci context "validation patterns" -f src/api/handlers.py
+oak-dev ci context "validation patterns" -f src/api/handlers.py
 
 # Get context with specific files in focus
-oak ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
+oak-dev ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
 ```
 
 ## Example: Finding Similar Implementations
@@ -70,13 +70,13 @@ oak ci context "how auth middleware relates to session handling" -f src/middlewa
 
 ```bash
 # 1. Find existing endpoint implementations
-oak ci search "REST API endpoint handler" --type code
+oak-dev ci search "REST API endpoint handler" --type code
 
 # 2. Find validation patterns
-oak ci search "input validation for API requests" --type code
+oak-dev ci search "input validation for API requests" --type code
 
 # 3. Find error handling patterns
-oak ci search "API error response formatting" --type code
+oak-dev ci search "API error response formatting" --type code
 ```
 
 **What you'll find**: Consistent patterns used elsewhere, even if the endpoints are in different modules or use different naming conventions.
@@ -92,7 +92,7 @@ oak ci search "API error response formatting" --type code
 # - "token_refresh" (authentication adjacent)
 
 # Semantic search finds them all:
-oak ci search "user authentication and authorization" --type code -n 20
+oak-dev ci search "user authentication and authorization" --type code -n 20
 ```
 
 ## Example: Understanding Component Relationships
@@ -101,13 +101,13 @@ oak ci search "user authentication and authorization" --type code -n 20
 
 ```bash
 # 1. Search for code mentioning both concepts
-oak ci search "OrderService inventory management"
+oak-dev ci search "OrderService inventory management"
 
 # 2. Get broader context
-oak ci context "relationship between orders and inventory"
+oak-dev ci context "relationship between orders and inventory"
 
 # 3. Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 ```
 
 **What you'll find**: Semantic search reveals event handlers, shared models, and integration points that aren't obvious from imports alone.
@@ -120,7 +120,7 @@ oak ci search "order creation inventory update"
 - Increase `-n` limit when exploring broadly
 - Use `--type code` to focus on implementation (exclude memories)
 - Combine multiple searches to build complete picture
-- Combine with `oak ci context` for richer understanding
+- Combine with `oak-dev ci context` for richer understanding
 
 ## Output
 
@@ -131,8 +131,8 @@ Results include:
 
 ```bash
 # JSON output (default) - good for parsing
-oak ci search "database transactions" -f json
+oak-dev ci search "database transactions" -f json
 
 # Text output - good for reading
-oak ci search "database transactions" -f text
+oak-dev ci search "database transactions" -f text
 ```

--- a/.claude/skills/codebase-intelligence/references/impact-analysis.md
+++ b/.claude/skills/codebase-intelligence/references/impact-analysis.md
@@ -22,23 +22,23 @@ Semantic search finds code related by meaning. When you change how something wor
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 
 # Search for code using similar patterns
-oak ci search "code that depends on JWT token format" --type code
+oak-dev ci search "code that depends on JWT token format" --type code
 ```
 
 ### Check for related memories
 
 ```bash
 # Find past learnings that might be relevant
-oak ci search "gotchas with auth changes" --type memory
+oak-dev ci search "gotchas with auth changes" --type memory
 
 # Find decisions that might be affected
-oak ci search "decisions about token handling"
+oak-dev ci search "decisions about token handling"
 ```
 
 ## Example: Before Refactoring
@@ -47,16 +47,16 @@ oak ci search "decisions about token handling"
 
 ```bash
 # 1. Find all code conceptually related to payment processing
-oak ci search "payment processing flow" --type code -n 20
+oak-dev ci search "payment processing flow" --type code -n 20
 
 # 2. Find code that handles payment errors (often missed)
-oak ci search "payment error handling and recovery" --type code
+oak-dev ci search "payment error handling and recovery" --type code
 
 # 3. Find related integrations
-oak ci search "payment gateway integration" --type code
+oak-dev ci search "payment gateway integration" --type code
 
 # 4. Check for past issues/decisions
-oak ci search "payment processing gotchas" --type memory
+oak-dev ci search "payment processing gotchas" --type memory
 ```
 
 **What you'll find**:
@@ -74,25 +74,25 @@ Many of these won't show up in import analysis!
 
 ```bash
 # Find all code that might parse this response
-oak ci search "user API response handling" --type code
+oak-dev ci search "user API response handling" --type code
 
 # Find frontend code consuming this API
-oak ci search "fetch user data from API" --type code
+oak-dev ci search "fetch user data from API" --type code
 
 # Find tests that might break
-oak ci search "user API endpoint tests" --type code
+oak-dev ci search "user API endpoint tests" --type code
 
 # Check for integration patterns
-oak ci context "code that depends on user API format"
+oak-dev ci context "code that depends on user API format"
 ```
 
 ## Impact Analysis Workflow
 
 1. **Identify the change**: What are you modifying?
-2. **Search for direct usage**: `oak ci search "ComponentName" --type code`
-3. **Search for conceptual usage**: `oak ci search "what ComponentName does" --type code`
-4. **Check for patterns**: `oak ci search "code using similar patterns" --type code`
-5. **Review memories**: `oak ci search "past issues with this area" --type memory`
+2. **Search for direct usage**: `oak-dev ci search "ComponentName" --type code`
+3. **Search for conceptual usage**: `oak-dev ci search "what ComponentName does" --type code`
+4. **Check for patterns**: `oak-dev ci search "code using similar patterns" --type code`
+5. **Review memories**: `oak-dev ci search "past issues with this area" --type memory`
 6. **Read the results**: Assess which code might need updates
 
 ## Tips
@@ -101,4 +101,4 @@ oak ci context "code that depends on user API format"
 - Search for what the code *does*, not just its name
 - Include error handling and edge cases in your search
 - Check memories for past issues in this area
-- Use `oak ci context` with the file you're changing for focused results
+- Use `oak-dev ci context` with the file you're changing for focused results

--- a/.claude/skills/codebase-intelligence/references/querying-databases.md
+++ b/.claude/skills/codebase-intelligence/references/querying-databases.md
@@ -19,7 +19,7 @@ Use direct SQL when browsing the dashboard is insufficient and detailed analysis
 - Full-text keyword search (FTS5 `MATCH` — different from semantic vector search)
 - When the CI daemon is not running (SQLite is always readable directly)
 
-**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak ci remember`.
+**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak-dev ci remember`.
 
 ## Database Location
 
@@ -69,13 +69,13 @@ For everyday codebase intelligence (semantic search, storing memories, retrievin
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search (code, memories, plans) |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory or learning |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
-| — | `oak ci memories --type gotcha` | Browse memories by type |
-| — | `oak ci sessions` | List session summaries |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search (code, memories, plans) |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory or learning |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
+| — | `oak-dev ci memories --type gotcha` | Browse memories by type |
+| — | `oak-dev ci sessions` | List session summaries |
 
-Check daemon status with `oak ci status`. Start with `oak ci start` if needed.
+Check daemon status with `oak-dev ci status`. Start with `oak-dev ci start` if needed.
 
 ## Important Notes
 
@@ -99,10 +99,10 @@ For complete schema DDL and advanced query patterns, consult:
 For automated analysis that runs these queries and produces reports, use the analysis agent:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.claude/skills/project-governance/SKILL.md
+++ b/.claude/skills/project-governance/SKILL.md
@@ -26,16 +26,16 @@ Create, modify, and maintain project constitutions, agent instruction files, and
 ### Create an RFC
 
 ```bash
-oak rfc create --title "Add caching layer" --template feature
-oak rfc list
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc create --title "Add caching layer" --template feature
+oak-dev rfc list
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ### Sync agent instruction files
 
 ```bash
-oak rules sync-agents          # Sync constitution references to all agent files
-oak rules detect-existing      # Discover all configured agent instruction files
+oak-dev rules sync-agents          # Sync constitution references to all agent files
+oak-dev rules detect-existing      # Discover all configured agent instruction files
 ```
 
 ## Commands Reference
@@ -44,21 +44,21 @@ oak rules detect-existing      # Discover all configured agent instruction files
 
 | Command | Purpose |
 |---------|---------|
-| `oak rules sync-agents` | Sync constitution references to all agent instruction files |
-| `oak rules sync-agents --dry-run` | Preview what files will be checked/updated |
-| `oak rules detect-existing` | Discover all configured agent instruction files |
-| `oak rules detect-existing --json` | Machine-readable output of agent files |
+| `oak-dev rules sync-agents` | Sync constitution references to all agent instruction files |
+| `oak-dev rules sync-agents --dry-run` | Preview what files will be checked/updated |
+| `oak-dev rules detect-existing` | Discover all configured agent instruction files |
+| `oak-dev rules detect-existing --json` | Machine-readable output of agent files |
 
 ### RFC commands
 
 | Command | Purpose |
 |---------|---------|
-| `oak rfc create --title "..." --template <type>` | Create a new RFC |
-| `oak rfc list` | List all RFCs |
-| `oak rfc validate <path>` | Validate RFC structure and content |
-| `oak rfc show <path>` | Show RFC details |
-| `oak rfc adopt <path>` | Mark RFC as adopted |
-| `oak rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
+| `oak-dev rfc create --title "..." --template <type>` | Create a new RFC |
+| `oak-dev rfc list` | List all RFCs |
+| `oak-dev rfc validate <path>` | Validate RFC structure and content |
+| `oak-dev rfc show <path>` | Show RFC details |
+| `oak-dev rfc adopt <path>` | Mark RFC as adopted |
+| `oak-dev rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
 
 ## When to Use
 
@@ -98,16 +98,16 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 
 1. **Read** the current constitution (`oak/constitution.md`)
 2. **Add** the full rule to the appropriate section using RFC 2119 language (MUST, SHOULD, MAY)
-3. **Sync** to all agent files: `oak rules sync-agents`
+3. **Sync** to all agent files: `oak-dev rules sync-agents`
 
 **CRITICAL:** Rules MUST be added to the constitution FIRST, then synced to agent files. Never add a rule only to an agent file.
 
 ### RFC lifecycle
 
-1. **Create**: `oak rfc create --title "..." --template feature --author "Name"`
+1. **Create**: `oak-dev rfc create --title "..." --template feature --author "Name"`
 2. **Fill in**: Problem context, proposed solution, trade-offs, alternatives
 3. **Review**: Use the review checklist (see `references/reviewing-rfcs.md`)
-4. **Adopt or abandon**: `oak rfc adopt <path>` or `oak rfc abandon <path> --reason "..."`
+4. **Adopt or abandon**: `oak-dev rfc adopt <path>` or `oak-dev rfc abandon <path> --reason "..."`
 
 ### RFC review checklist (summary)
 
@@ -131,7 +131,7 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 ## Files
 
 - Constitution: `oak/constitution.md` or `.constitution.md`
-- Agent files: Run `oak rules detect-existing` to discover all agent instruction files
+- Agent files: Run `oak-dev rules detect-existing` to discover all agent instruction files
 - RFCs: `oak/rfc/RFC-XXX-short-title.md`
 
 ## Deep Dives

--- a/.claude/skills/project-governance/references/agent-files-guide.md
+++ b/.claude/skills/project-governance/references/agent-files-guide.md
@@ -15,7 +15,7 @@ Agent instruction files are **short, operational documents** that:
 ### Option 1: Use OAK's sync command
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ### Option 2: Create manually
@@ -65,8 +65,8 @@ Do NOT hardcode agent file names. Use OAK's built-in commands:
 
 ```bash
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 Agent files are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -77,10 +77,10 @@ When the constitution is updated, sync changes to all agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## What Makes a Good Agent File

--- a/.claude/skills/project-governance/references/constitution-guide.md
+++ b/.claude/skills/project-governance/references/constitution-guide.md
@@ -116,7 +116,7 @@ Create `oak/constitution.md` (or `.constitution.md` at root):
 After creating the constitution, create agent files that reference it:
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## Adding Rules to Existing Constitution
@@ -130,8 +130,8 @@ oak rules sync-agents
 cat oak/constitution.md  # or .constitution.md
 
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 **Do NOT hardcode agent file names.** Agents are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -168,13 +168,13 @@ After the constitution is updated, sync to all configured agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
-If manual updates are needed, use `oak rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
+If manual updates are needed, use `oak-dev rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
 
 ```markdown
 ## [Rule Name]
@@ -182,7 +182,7 @@ If manual updates are needed, use `oak rules detect-existing --json` to get the 
 **MUST NOT** [brief prohibition]. See §[section] of `oak/constitution.md` for the full rule, rationale, and verification command.
 ```
 
-**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak rules detect-existing`.
+**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak-dev rules detect-existing`.
 
 ## Example Workflow
 
@@ -196,4 +196,4 @@ User: "We need to establish coding standards for this Python project"
    - Quality gate (`make check` or equivalent)
    - Anchor files (point to best existing modules)
 3. **Create agent files** referencing the constitution
-4. **Sync**: `oak rules sync-agents`
+4. **Sync**: `oak-dev rules sync-agents`

--- a/.claude/skills/project-governance/references/creating-rfcs.md
+++ b/.claude/skills/project-governance/references/creating-rfcs.md
@@ -22,13 +22,13 @@ Use this workflow when:
 
 ```bash
 # Create an RFC interactively
-oak rfc create --title "Add caching layer" --template feature
+oak-dev rfc create --title "Add caching layer" --template feature
 
 # List existing RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate an RFC
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ## RFC Templates
@@ -70,7 +70,7 @@ What else did we consider? Why not those?
 ### 1. Create the RFC
 
 ```bash
-oak rfc create --title "Your RFC Title" --template feature --author "Your Name"
+oak-dev rfc create --title "Your RFC Title" --template feature --author "Your Name"
 ```
 
 This creates a file in `oak/rfc/` with the proper structure.
@@ -88,13 +88,13 @@ Edit the generated file to add:
 The RFC is now ready for team review. Once approved:
 
 ```bash
-oak rfc adopt oak/rfc/RFC-XXX-your-rfc.md
+oak-dev rfc adopt oak/rfc/RFC-XXX-your-rfc.md
 ```
 
 Or if abandoned:
 
 ```bash
-oak rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
+oak-dev rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
 ```
 
 ## Tips

--- a/.claude/skills/project-governance/references/reviewing-rfcs.md
+++ b/.claude/skills/project-governance/references/reviewing-rfcs.md
@@ -21,13 +21,13 @@ Use this workflow when:
 
 ```bash
 # List all RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate a specific RFC
-oak rfc validate oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc validate oak/rfc/RFC-001-your-rfc.md
 
 # Show RFC details
-oak rfc show oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc show oak/rfc/RFC-001-your-rfc.md
 ```
 
 ## Review Checklist
@@ -88,7 +88,7 @@ When providing feedback, structure it as:
 Run automated validation:
 
 ```bash
-oak rfc validate oak/rfc/RFC-XXX-title.md
+oak-dev rfc validate oak/rfc/RFC-XXX-title.md
 ```
 
 This checks:
@@ -111,5 +111,5 @@ This checks:
 RFCs are in `oak/rfc/` directory. List all with:
 
 ```bash
-oak rfc list
+oak-dev rfc list
 ```

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,5 +1,5 @@
 notify = [
-    "oak",
+    "oak-dev",
     "ci",
     "notify",
     "--agent",
@@ -7,7 +7,7 @@ notify = [
 ]
 
 [mcp_servers.oak-ci]
-command = "oak"
+command = "oak-dev"
 args = [
     "ci",
     "mcp",

--- a/.codex/skills/codebase-intelligence/SKILL.md
+++ b/.codex/skills/codebase-intelligence/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   in previous sessions, looking up past conversations or outcomes, querying
   session history, checking activity logs, browsing memories, running SQL
   against activities.db, or exploring patterns that grep would miss. Do NOT use
-  for storing memories — use oak_remember or oak ci remember instead.
+  for storing memories — use oak_remember or oak-dev ci remember instead.
 allowed-tools: Bash, Read
 user-invocable: true
 ---
@@ -23,20 +23,20 @@ Search, analyze, and query your codebase using semantic vector search, impact an
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 ```
 
 ### Impact analysis
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 ```
 
 ### Session and memory lookup
@@ -47,10 +47,10 @@ sqlite3 -readonly -header -column .oak/ci/activities.db \
   "SELECT id, agent, title, status, datetime(created_at_epoch, 'unixepoch', 'localtime') as started FROM sessions ORDER BY created_at_epoch DESC LIMIT 5;"
 
 # Search past decisions and learnings
-oak ci search "authentication refactor decision" --type memory
+oak-dev ci search "authentication refactor decision" --type memory
 
 # Browse memories by type
-oak ci memories --type decision
+oak-dev ci memories --type decision
 ```
 
 ### Database query
@@ -66,22 +66,22 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "SELECT count(*) FROM se
 
 | Command | Purpose |
 |---------|---------|
-| `oak ci search "query" --type code` | Semantic vector search for code |
-| `oak ci search "query" --type memory` | Semantic search for memories |
-| `oak ci search "query" -n 20` | Broader search with more results |
-| `oak ci context "task" -f <file>` | Get context for current work |
-| `oak ci remember "observation"` | Store a memory (NOT via SQL) |
-| `oak ci memories --type gotcha` | Browse memories by type |
-| `oak ci sessions` | List session summaries |
-| `oak ci status` | Check daemon status |
+| `oak-dev ci search "query" --type code` | Semantic vector search for code |
+| `oak-dev ci search "query" --type memory` | Semantic search for memories |
+| `oak-dev ci search "query" -n 20` | Broader search with more results |
+| `oak-dev ci context "task" -f <file>` | Get context for current work |
+| `oak-dev ci remember "observation"` | Store a memory (NOT via SQL) |
+| `oak-dev ci memories --type gotcha` | Browse memories by type |
+| `oak-dev ci sessions` | List session summaries |
+| `oak-dev ci status` | Check daemon status |
 
 ### MCP tools
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
 
 ### Direct SQL
 
@@ -93,15 +93,15 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 
 | Need | Tool | Example |
 |------|------|---------|
-| Find similar implementations | `oak ci search --type code` | "retry with exponential backoff" |
-| Understand component relationships | `oak ci context` | "how auth middleware relates to session handling" |
-| Assess refactoring risk | `oak ci search --type code -n 20` | "PaymentProcessor error handling" |
-| Find past decisions/gotchas | `oak ci search --type memory` | "gotchas with auth changes" |
+| Find similar implementations | `oak-dev ci search --type code` | "retry with exponential backoff" |
+| Understand component relationships | `oak-dev ci context` | "how auth middleware relates to session handling" |
+| Assess refactoring risk | `oak-dev ci search --type code -n 20` | "PaymentProcessor error handling" |
+| Find past decisions/gotchas | `oak-dev ci search --type memory` | "gotchas with auth changes" |
 | Recall previous discussions | `sqlite3 -readonly` | `SELECT title, summary FROM sessions WHERE ...` |
-| Find what was done before | `oak ci memories` / `sqlite3` | "what did we decide about caching?" |
+| Find what was done before | `oak-dev ci memories` / `sqlite3` | "what did we decide about caching?" |
 | Query session history | `sqlite3 -readonly` | `SELECT * FROM sessions ORDER BY ...` |
 | Aggregate usage stats | `sqlite3 -readonly` | `SELECT agent_name, sum(cost_usd) FROM agent_runs ...` |
-| Run automated analysis | `oak ci agent run` | `oak ci agent run usage-report` |
+| Run automated analysis | `oak-dev ci agent run` | `oak-dev ci agent run usage-report` |
 
 ## Why Semantic Search Over Grep
 
@@ -217,10 +217,10 @@ ORDER BY next_run_at_epoch;
 For automated analysis that runs queries and produces reports:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.codex/skills/codebase-intelligence/references/analysis-playbooks.md
+++ b/.codex/skills/codebase-intelligence/references/analysis-playbooks.md
@@ -2,7 +2,7 @@
 
 Structured multi-query workflows for analyzing CI data. Each playbook is a sequence of queries that build on each other to answer a specific question.
 
-These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak ci agent run <task-name>`).
+These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak-dev ci agent run <task-name>`).
 
 ## Playbook 1: Usage & Cost Analysis
 
@@ -223,10 +223,10 @@ LIMIT 10;
 These playbooks can be run automatically via the analysis agent:
 
 ```bash
-oak ci agent run usage-report          # Playbook 1
-oak ci agent run productivity-report   # Playbook 2
-oak ci agent run codebase-activity-report  # Playbook 3
-oak ci agent run prompt-analysis       # Playbook 4
+oak-dev ci agent run usage-report          # Playbook 1
+oak-dev ci agent run productivity-report   # Playbook 2
+oak-dev ci agent run codebase-activity-report  # Playbook 3
+oak-dev ci agent run prompt-analysis       # Playbook 4
 ```
 
 Reports are written to `oak/insights/` and can be committed to git for team visibility.

--- a/.codex/skills/codebase-intelligence/references/finding-related-code.md
+++ b/.codex/skills/codebase-intelligence/references/finding-related-code.md
@@ -29,39 +29,39 @@ Use this workflow when:
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 
 # More results for broader exploration
-oak ci search "error handling and logging" --type code -n 20
+oak-dev ci search "error handling and logging" --type code -n 20
 ```
 
 ### Discover component relationships
 
 ```bash
 # Find code related to two concepts (relationship)
-oak ci search "how does AuthService interact with TokenManager"
+oak-dev ci search "how does AuthService interact with TokenManager"
 
 # Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 
 # Get context about a specific relationship
-oak ci context "relationship between UserService and PaymentProcessor"
+oak-dev ci context "relationship between UserService and PaymentProcessor"
 ```
 
 ### Get context for current work
 
 ```bash
 # Find code related to files you're editing
-oak ci context "similar implementations" -f src/services/user.py
+oak-dev ci context "similar implementations" -f src/services/user.py
 
 # Find related code for a specific task
-oak ci context "validation patterns" -f src/api/handlers.py
+oak-dev ci context "validation patterns" -f src/api/handlers.py
 
 # Get context with specific files in focus
-oak ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
+oak-dev ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
 ```
 
 ## Example: Finding Similar Implementations
@@ -70,13 +70,13 @@ oak ci context "how auth middleware relates to session handling" -f src/middlewa
 
 ```bash
 # 1. Find existing endpoint implementations
-oak ci search "REST API endpoint handler" --type code
+oak-dev ci search "REST API endpoint handler" --type code
 
 # 2. Find validation patterns
-oak ci search "input validation for API requests" --type code
+oak-dev ci search "input validation for API requests" --type code
 
 # 3. Find error handling patterns
-oak ci search "API error response formatting" --type code
+oak-dev ci search "API error response formatting" --type code
 ```
 
 **What you'll find**: Consistent patterns used elsewhere, even if the endpoints are in different modules or use different naming conventions.
@@ -92,7 +92,7 @@ oak ci search "API error response formatting" --type code
 # - "token_refresh" (authentication adjacent)
 
 # Semantic search finds them all:
-oak ci search "user authentication and authorization" --type code -n 20
+oak-dev ci search "user authentication and authorization" --type code -n 20
 ```
 
 ## Example: Understanding Component Relationships
@@ -101,13 +101,13 @@ oak ci search "user authentication and authorization" --type code -n 20
 
 ```bash
 # 1. Search for code mentioning both concepts
-oak ci search "OrderService inventory management"
+oak-dev ci search "OrderService inventory management"
 
 # 2. Get broader context
-oak ci context "relationship between orders and inventory"
+oak-dev ci context "relationship between orders and inventory"
 
 # 3. Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 ```
 
 **What you'll find**: Semantic search reveals event handlers, shared models, and integration points that aren't obvious from imports alone.
@@ -120,7 +120,7 @@ oak ci search "order creation inventory update"
 - Increase `-n` limit when exploring broadly
 - Use `--type code` to focus on implementation (exclude memories)
 - Combine multiple searches to build complete picture
-- Combine with `oak ci context` for richer understanding
+- Combine with `oak-dev ci context` for richer understanding
 
 ## Output
 
@@ -131,8 +131,8 @@ Results include:
 
 ```bash
 # JSON output (default) - good for parsing
-oak ci search "database transactions" -f json
+oak-dev ci search "database transactions" -f json
 
 # Text output - good for reading
-oak ci search "database transactions" -f text
+oak-dev ci search "database transactions" -f text
 ```

--- a/.codex/skills/codebase-intelligence/references/impact-analysis.md
+++ b/.codex/skills/codebase-intelligence/references/impact-analysis.md
@@ -22,23 +22,23 @@ Semantic search finds code related by meaning. When you change how something wor
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 
 # Search for code using similar patterns
-oak ci search "code that depends on JWT token format" --type code
+oak-dev ci search "code that depends on JWT token format" --type code
 ```
 
 ### Check for related memories
 
 ```bash
 # Find past learnings that might be relevant
-oak ci search "gotchas with auth changes" --type memory
+oak-dev ci search "gotchas with auth changes" --type memory
 
 # Find decisions that might be affected
-oak ci search "decisions about token handling"
+oak-dev ci search "decisions about token handling"
 ```
 
 ## Example: Before Refactoring
@@ -47,16 +47,16 @@ oak ci search "decisions about token handling"
 
 ```bash
 # 1. Find all code conceptually related to payment processing
-oak ci search "payment processing flow" --type code -n 20
+oak-dev ci search "payment processing flow" --type code -n 20
 
 # 2. Find code that handles payment errors (often missed)
-oak ci search "payment error handling and recovery" --type code
+oak-dev ci search "payment error handling and recovery" --type code
 
 # 3. Find related integrations
-oak ci search "payment gateway integration" --type code
+oak-dev ci search "payment gateway integration" --type code
 
 # 4. Check for past issues/decisions
-oak ci search "payment processing gotchas" --type memory
+oak-dev ci search "payment processing gotchas" --type memory
 ```
 
 **What you'll find**:
@@ -74,25 +74,25 @@ Many of these won't show up in import analysis!
 
 ```bash
 # Find all code that might parse this response
-oak ci search "user API response handling" --type code
+oak-dev ci search "user API response handling" --type code
 
 # Find frontend code consuming this API
-oak ci search "fetch user data from API" --type code
+oak-dev ci search "fetch user data from API" --type code
 
 # Find tests that might break
-oak ci search "user API endpoint tests" --type code
+oak-dev ci search "user API endpoint tests" --type code
 
 # Check for integration patterns
-oak ci context "code that depends on user API format"
+oak-dev ci context "code that depends on user API format"
 ```
 
 ## Impact Analysis Workflow
 
 1. **Identify the change**: What are you modifying?
-2. **Search for direct usage**: `oak ci search "ComponentName" --type code`
-3. **Search for conceptual usage**: `oak ci search "what ComponentName does" --type code`
-4. **Check for patterns**: `oak ci search "code using similar patterns" --type code`
-5. **Review memories**: `oak ci search "past issues with this area" --type memory`
+2. **Search for direct usage**: `oak-dev ci search "ComponentName" --type code`
+3. **Search for conceptual usage**: `oak-dev ci search "what ComponentName does" --type code`
+4. **Check for patterns**: `oak-dev ci search "code using similar patterns" --type code`
+5. **Review memories**: `oak-dev ci search "past issues with this area" --type memory`
 6. **Read the results**: Assess which code might need updates
 
 ## Tips
@@ -101,4 +101,4 @@ oak ci context "code that depends on user API format"
 - Search for what the code *does*, not just its name
 - Include error handling and edge cases in your search
 - Check memories for past issues in this area
-- Use `oak ci context` with the file you're changing for focused results
+- Use `oak-dev ci context` with the file you're changing for focused results

--- a/.codex/skills/codebase-intelligence/references/querying-databases.md
+++ b/.codex/skills/codebase-intelligence/references/querying-databases.md
@@ -19,7 +19,7 @@ Use direct SQL when browsing the dashboard is insufficient and detailed analysis
 - Full-text keyword search (FTS5 `MATCH` — different from semantic vector search)
 - When the CI daemon is not running (SQLite is always readable directly)
 
-**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak ci remember`.
+**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak-dev ci remember`.
 
 ## Database Location
 
@@ -69,13 +69,13 @@ For everyday codebase intelligence (semantic search, storing memories, retrievin
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search (code, memories, plans) |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory or learning |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
-| — | `oak ci memories --type gotcha` | Browse memories by type |
-| — | `oak ci sessions` | List session summaries |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search (code, memories, plans) |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory or learning |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
+| — | `oak-dev ci memories --type gotcha` | Browse memories by type |
+| — | `oak-dev ci sessions` | List session summaries |
 
-Check daemon status with `oak ci status`. Start with `oak ci start` if needed.
+Check daemon status with `oak-dev ci status`. Start with `oak-dev ci start` if needed.
 
 ## Important Notes
 
@@ -99,10 +99,10 @@ For complete schema DDL and advanced query patterns, consult:
 For automated analysis that runs these queries and produces reports, use the analysis agent:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.codex/skills/project-governance/SKILL.md
+++ b/.codex/skills/project-governance/SKILL.md
@@ -26,16 +26,16 @@ Create, modify, and maintain project constitutions, agent instruction files, and
 ### Create an RFC
 
 ```bash
-oak rfc create --title "Add caching layer" --template feature
-oak rfc list
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc create --title "Add caching layer" --template feature
+oak-dev rfc list
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ### Sync agent instruction files
 
 ```bash
-oak rules sync-agents          # Sync constitution references to all agent files
-oak rules detect-existing      # Discover all configured agent instruction files
+oak-dev rules sync-agents          # Sync constitution references to all agent files
+oak-dev rules detect-existing      # Discover all configured agent instruction files
 ```
 
 ## Commands Reference
@@ -44,21 +44,21 @@ oak rules detect-existing      # Discover all configured agent instruction files
 
 | Command | Purpose |
 |---------|---------|
-| `oak rules sync-agents` | Sync constitution references to all agent instruction files |
-| `oak rules sync-agents --dry-run` | Preview what files will be checked/updated |
-| `oak rules detect-existing` | Discover all configured agent instruction files |
-| `oak rules detect-existing --json` | Machine-readable output of agent files |
+| `oak-dev rules sync-agents` | Sync constitution references to all agent instruction files |
+| `oak-dev rules sync-agents --dry-run` | Preview what files will be checked/updated |
+| `oak-dev rules detect-existing` | Discover all configured agent instruction files |
+| `oak-dev rules detect-existing --json` | Machine-readable output of agent files |
 
 ### RFC commands
 
 | Command | Purpose |
 |---------|---------|
-| `oak rfc create --title "..." --template <type>` | Create a new RFC |
-| `oak rfc list` | List all RFCs |
-| `oak rfc validate <path>` | Validate RFC structure and content |
-| `oak rfc show <path>` | Show RFC details |
-| `oak rfc adopt <path>` | Mark RFC as adopted |
-| `oak rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
+| `oak-dev rfc create --title "..." --template <type>` | Create a new RFC |
+| `oak-dev rfc list` | List all RFCs |
+| `oak-dev rfc validate <path>` | Validate RFC structure and content |
+| `oak-dev rfc show <path>` | Show RFC details |
+| `oak-dev rfc adopt <path>` | Mark RFC as adopted |
+| `oak-dev rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
 
 ## When to Use
 
@@ -98,16 +98,16 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 
 1. **Read** the current constitution (`oak/constitution.md`)
 2. **Add** the full rule to the appropriate section using RFC 2119 language (MUST, SHOULD, MAY)
-3. **Sync** to all agent files: `oak rules sync-agents`
+3. **Sync** to all agent files: `oak-dev rules sync-agents`
 
 **CRITICAL:** Rules MUST be added to the constitution FIRST, then synced to agent files. Never add a rule only to an agent file.
 
 ### RFC lifecycle
 
-1. **Create**: `oak rfc create --title "..." --template feature --author "Name"`
+1. **Create**: `oak-dev rfc create --title "..." --template feature --author "Name"`
 2. **Fill in**: Problem context, proposed solution, trade-offs, alternatives
 3. **Review**: Use the review checklist (see `references/reviewing-rfcs.md`)
-4. **Adopt or abandon**: `oak rfc adopt <path>` or `oak rfc abandon <path> --reason "..."`
+4. **Adopt or abandon**: `oak-dev rfc adopt <path>` or `oak-dev rfc abandon <path> --reason "..."`
 
 ### RFC review checklist (summary)
 
@@ -131,7 +131,7 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 ## Files
 
 - Constitution: `oak/constitution.md` or `.constitution.md`
-- Agent files: Run `oak rules detect-existing` to discover all agent instruction files
+- Agent files: Run `oak-dev rules detect-existing` to discover all agent instruction files
 - RFCs: `oak/rfc/RFC-XXX-short-title.md`
 
 ## Deep Dives

--- a/.codex/skills/project-governance/references/agent-files-guide.md
+++ b/.codex/skills/project-governance/references/agent-files-guide.md
@@ -15,7 +15,7 @@ Agent instruction files are **short, operational documents** that:
 ### Option 1: Use OAK's sync command
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ### Option 2: Create manually
@@ -65,8 +65,8 @@ Do NOT hardcode agent file names. Use OAK's built-in commands:
 
 ```bash
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 Agent files are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -77,10 +77,10 @@ When the constitution is updated, sync changes to all agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## What Makes a Good Agent File

--- a/.codex/skills/project-governance/references/constitution-guide.md
+++ b/.codex/skills/project-governance/references/constitution-guide.md
@@ -116,7 +116,7 @@ Create `oak/constitution.md` (or `.constitution.md` at root):
 After creating the constitution, create agent files that reference it:
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## Adding Rules to Existing Constitution
@@ -130,8 +130,8 @@ oak rules sync-agents
 cat oak/constitution.md  # or .constitution.md
 
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 **Do NOT hardcode agent file names.** Agents are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -168,13 +168,13 @@ After the constitution is updated, sync to all configured agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
-If manual updates are needed, use `oak rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
+If manual updates are needed, use `oak-dev rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
 
 ```markdown
 ## [Rule Name]
@@ -182,7 +182,7 @@ If manual updates are needed, use `oak rules detect-existing --json` to get the 
 **MUST NOT** [brief prohibition]. See §[section] of `oak/constitution.md` for the full rule, rationale, and verification command.
 ```
 
-**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak rules detect-existing`.
+**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak-dev rules detect-existing`.
 
 ## Example Workflow
 
@@ -196,4 +196,4 @@ User: "We need to establish coding standards for this Python project"
    - Quality gate (`make check` or equivalent)
    - Anchor files (point to best existing modules)
 3. **Create agent files** referencing the constitution
-4. **Sync**: `oak rules sync-agents`
+4. **Sync**: `oak-dev rules sync-agents`

--- a/.codex/skills/project-governance/references/creating-rfcs.md
+++ b/.codex/skills/project-governance/references/creating-rfcs.md
@@ -22,13 +22,13 @@ Use this workflow when:
 
 ```bash
 # Create an RFC interactively
-oak rfc create --title "Add caching layer" --template feature
+oak-dev rfc create --title "Add caching layer" --template feature
 
 # List existing RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate an RFC
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ## RFC Templates
@@ -70,7 +70,7 @@ What else did we consider? Why not those?
 ### 1. Create the RFC
 
 ```bash
-oak rfc create --title "Your RFC Title" --template feature --author "Your Name"
+oak-dev rfc create --title "Your RFC Title" --template feature --author "Your Name"
 ```
 
 This creates a file in `oak/rfc/` with the proper structure.
@@ -88,13 +88,13 @@ Edit the generated file to add:
 The RFC is now ready for team review. Once approved:
 
 ```bash
-oak rfc adopt oak/rfc/RFC-XXX-your-rfc.md
+oak-dev rfc adopt oak/rfc/RFC-XXX-your-rfc.md
 ```
 
 Or if abandoned:
 
 ```bash
-oak rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
+oak-dev rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
 ```
 
 ## Tips

--- a/.codex/skills/project-governance/references/reviewing-rfcs.md
+++ b/.codex/skills/project-governance/references/reviewing-rfcs.md
@@ -21,13 +21,13 @@ Use this workflow when:
 
 ```bash
 # List all RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate a specific RFC
-oak rfc validate oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc validate oak/rfc/RFC-001-your-rfc.md
 
 # Show RFC details
-oak rfc show oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc show oak/rfc/RFC-001-your-rfc.md
 ```
 
 ## Review Checklist
@@ -88,7 +88,7 @@ When providing feedback, structure it as:
 Run automated validation:
 
 ```bash
-oak rfc validate oak/rfc/RFC-XXX-title.md
+oak-dev rfc validate oak/rfc/RFC-XXX-title.md
 ```
 
 This checks:
@@ -111,5 +111,5 @@ This checks:
 RFCs are in `oak/rfc/` directory. List all with:
 
 ```bash
-oak rfc list
+oak-dev rfc list
 ```

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -3,62 +3,62 @@
   "hooks": {
     "sessionStart": [
       {
-        "command": "oak ci hook sessionStart --agent cursor"
+        "command": "oak-dev ci hook sessionStart --agent cursor"
       }
     ],
     "beforeSubmitPrompt": [
       {
-        "command": "oak ci hook beforeSubmitPrompt --agent cursor"
+        "command": "oak-dev ci hook beforeSubmitPrompt --agent cursor"
       }
     ],
     "afterFileEdit": [
       {
-        "command": "oak ci hook afterFileEdit --agent cursor"
+        "command": "oak-dev ci hook afterFileEdit --agent cursor"
       }
     ],
     "afterAgentResponse": [
       {
-        "command": "oak ci hook afterAgentResponse --agent cursor"
+        "command": "oak-dev ci hook afterAgentResponse --agent cursor"
       }
     ],
     "afterAgentThought": [
       {
-        "command": "oak ci hook afterAgentThought --agent cursor"
+        "command": "oak-dev ci hook afterAgentThought --agent cursor"
       }
     ],
     "postToolUse": [
       {
-        "command": "oak ci hook postToolUse --agent cursor"
+        "command": "oak-dev ci hook postToolUse --agent cursor"
       }
     ],
     "preCompact": [
       {
-        "command": "oak ci hook preCompact --agent cursor"
+        "command": "oak-dev ci hook preCompact --agent cursor"
       }
     ],
     "stop": [
       {
-        "command": "oak ci hook stop --agent cursor"
+        "command": "oak-dev ci hook stop --agent cursor"
       }
     ],
     "sessionEnd": [
       {
-        "command": "oak ci hook sessionEnd --agent cursor"
+        "command": "oak-dev ci hook sessionEnd --agent cursor"
       }
     ],
     "postToolUseFailure": [
       {
-        "command": "oak ci hook postToolUseFailure --agent cursor"
+        "command": "oak-dev ci hook postToolUseFailure --agent cursor"
       }
     ],
     "subagentStart": [
       {
-        "command": "oak ci hook subagentStart --agent cursor"
+        "command": "oak-dev ci hook subagentStart --agent cursor"
       }
     ],
     "subagentStop": [
       {
-        "command": "oak ci hook subagentStop --agent cursor"
+        "command": "oak-dev ci hook subagentStop --agent cursor"
       }
     ]
   }

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "oak-ci": {
-      "command": "oak",
+      "command": "oak-dev",
       "args": [
         "ci",
         "mcp"

--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,5 +1,6 @@
 {
   "chat.tools.terminal.autoApprove": {
-    "oak": true
+    "oak": true,
+    "oak-dev": true
   }
 }

--- a/.cursor/skills/codebase-intelligence/SKILL.md
+++ b/.cursor/skills/codebase-intelligence/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   in previous sessions, looking up past conversations or outcomes, querying
   session history, checking activity logs, browsing memories, running SQL
   against activities.db, or exploring patterns that grep would miss. Do NOT use
-  for storing memories — use oak_remember or oak ci remember instead.
+  for storing memories — use oak_remember or oak-dev ci remember instead.
 allowed-tools: Bash, Read
 user-invocable: true
 ---
@@ -23,20 +23,20 @@ Search, analyze, and query your codebase using semantic vector search, impact an
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 ```
 
 ### Impact analysis
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 ```
 
 ### Session and memory lookup
@@ -47,10 +47,10 @@ sqlite3 -readonly -header -column .oak/ci/activities.db \
   "SELECT id, agent, title, status, datetime(created_at_epoch, 'unixepoch', 'localtime') as started FROM sessions ORDER BY created_at_epoch DESC LIMIT 5;"
 
 # Search past decisions and learnings
-oak ci search "authentication refactor decision" --type memory
+oak-dev ci search "authentication refactor decision" --type memory
 
 # Browse memories by type
-oak ci memories --type decision
+oak-dev ci memories --type decision
 ```
 
 ### Database query
@@ -66,22 +66,22 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "SELECT count(*) FROM se
 
 | Command | Purpose |
 |---------|---------|
-| `oak ci search "query" --type code` | Semantic vector search for code |
-| `oak ci search "query" --type memory` | Semantic search for memories |
-| `oak ci search "query" -n 20` | Broader search with more results |
-| `oak ci context "task" -f <file>` | Get context for current work |
-| `oak ci remember "observation"` | Store a memory (NOT via SQL) |
-| `oak ci memories --type gotcha` | Browse memories by type |
-| `oak ci sessions` | List session summaries |
-| `oak ci status` | Check daemon status |
+| `oak-dev ci search "query" --type code` | Semantic vector search for code |
+| `oak-dev ci search "query" --type memory` | Semantic search for memories |
+| `oak-dev ci search "query" -n 20` | Broader search with more results |
+| `oak-dev ci context "task" -f <file>` | Get context for current work |
+| `oak-dev ci remember "observation"` | Store a memory (NOT via SQL) |
+| `oak-dev ci memories --type gotcha` | Browse memories by type |
+| `oak-dev ci sessions` | List session summaries |
+| `oak-dev ci status` | Check daemon status |
 
 ### MCP tools
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
 
 ### Direct SQL
 
@@ -93,15 +93,15 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 
 | Need | Tool | Example |
 |------|------|---------|
-| Find similar implementations | `oak ci search --type code` | "retry with exponential backoff" |
-| Understand component relationships | `oak ci context` | "how auth middleware relates to session handling" |
-| Assess refactoring risk | `oak ci search --type code -n 20` | "PaymentProcessor error handling" |
-| Find past decisions/gotchas | `oak ci search --type memory` | "gotchas with auth changes" |
+| Find similar implementations | `oak-dev ci search --type code` | "retry with exponential backoff" |
+| Understand component relationships | `oak-dev ci context` | "how auth middleware relates to session handling" |
+| Assess refactoring risk | `oak-dev ci search --type code -n 20` | "PaymentProcessor error handling" |
+| Find past decisions/gotchas | `oak-dev ci search --type memory` | "gotchas with auth changes" |
 | Recall previous discussions | `sqlite3 -readonly` | `SELECT title, summary FROM sessions WHERE ...` |
-| Find what was done before | `oak ci memories` / `sqlite3` | "what did we decide about caching?" |
+| Find what was done before | `oak-dev ci memories` / `sqlite3` | "what did we decide about caching?" |
 | Query session history | `sqlite3 -readonly` | `SELECT * FROM sessions ORDER BY ...` |
 | Aggregate usage stats | `sqlite3 -readonly` | `SELECT agent_name, sum(cost_usd) FROM agent_runs ...` |
-| Run automated analysis | `oak ci agent run` | `oak ci agent run usage-report` |
+| Run automated analysis | `oak-dev ci agent run` | `oak-dev ci agent run usage-report` |
 
 ## Why Semantic Search Over Grep
 
@@ -217,10 +217,10 @@ ORDER BY next_run_at_epoch;
 For automated analysis that runs queries and produces reports:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.cursor/skills/codebase-intelligence/references/analysis-playbooks.md
+++ b/.cursor/skills/codebase-intelligence/references/analysis-playbooks.md
@@ -2,7 +2,7 @@
 
 Structured multi-query workflows for analyzing CI data. Each playbook is a sequence of queries that build on each other to answer a specific question.
 
-These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak ci agent run <task-name>`).
+These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak-dev ci agent run <task-name>`).
 
 ## Playbook 1: Usage & Cost Analysis
 
@@ -223,10 +223,10 @@ LIMIT 10;
 These playbooks can be run automatically via the analysis agent:
 
 ```bash
-oak ci agent run usage-report          # Playbook 1
-oak ci agent run productivity-report   # Playbook 2
-oak ci agent run codebase-activity-report  # Playbook 3
-oak ci agent run prompt-analysis       # Playbook 4
+oak-dev ci agent run usage-report          # Playbook 1
+oak-dev ci agent run productivity-report   # Playbook 2
+oak-dev ci agent run codebase-activity-report  # Playbook 3
+oak-dev ci agent run prompt-analysis       # Playbook 4
 ```
 
 Reports are written to `oak/insights/` and can be committed to git for team visibility.

--- a/.cursor/skills/codebase-intelligence/references/finding-related-code.md
+++ b/.cursor/skills/codebase-intelligence/references/finding-related-code.md
@@ -29,39 +29,39 @@ Use this workflow when:
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 
 # More results for broader exploration
-oak ci search "error handling and logging" --type code -n 20
+oak-dev ci search "error handling and logging" --type code -n 20
 ```
 
 ### Discover component relationships
 
 ```bash
 # Find code related to two concepts (relationship)
-oak ci search "how does AuthService interact with TokenManager"
+oak-dev ci search "how does AuthService interact with TokenManager"
 
 # Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 
 # Get context about a specific relationship
-oak ci context "relationship between UserService and PaymentProcessor"
+oak-dev ci context "relationship between UserService and PaymentProcessor"
 ```
 
 ### Get context for current work
 
 ```bash
 # Find code related to files you're editing
-oak ci context "similar implementations" -f src/services/user.py
+oak-dev ci context "similar implementations" -f src/services/user.py
 
 # Find related code for a specific task
-oak ci context "validation patterns" -f src/api/handlers.py
+oak-dev ci context "validation patterns" -f src/api/handlers.py
 
 # Get context with specific files in focus
-oak ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
+oak-dev ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
 ```
 
 ## Example: Finding Similar Implementations
@@ -70,13 +70,13 @@ oak ci context "how auth middleware relates to session handling" -f src/middlewa
 
 ```bash
 # 1. Find existing endpoint implementations
-oak ci search "REST API endpoint handler" --type code
+oak-dev ci search "REST API endpoint handler" --type code
 
 # 2. Find validation patterns
-oak ci search "input validation for API requests" --type code
+oak-dev ci search "input validation for API requests" --type code
 
 # 3. Find error handling patterns
-oak ci search "API error response formatting" --type code
+oak-dev ci search "API error response formatting" --type code
 ```
 
 **What you'll find**: Consistent patterns used elsewhere, even if the endpoints are in different modules or use different naming conventions.
@@ -92,7 +92,7 @@ oak ci search "API error response formatting" --type code
 # - "token_refresh" (authentication adjacent)
 
 # Semantic search finds them all:
-oak ci search "user authentication and authorization" --type code -n 20
+oak-dev ci search "user authentication and authorization" --type code -n 20
 ```
 
 ## Example: Understanding Component Relationships
@@ -101,13 +101,13 @@ oak ci search "user authentication and authorization" --type code -n 20
 
 ```bash
 # 1. Search for code mentioning both concepts
-oak ci search "OrderService inventory management"
+oak-dev ci search "OrderService inventory management"
 
 # 2. Get broader context
-oak ci context "relationship between orders and inventory"
+oak-dev ci context "relationship between orders and inventory"
 
 # 3. Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 ```
 
 **What you'll find**: Semantic search reveals event handlers, shared models, and integration points that aren't obvious from imports alone.
@@ -120,7 +120,7 @@ oak ci search "order creation inventory update"
 - Increase `-n` limit when exploring broadly
 - Use `--type code` to focus on implementation (exclude memories)
 - Combine multiple searches to build complete picture
-- Combine with `oak ci context` for richer understanding
+- Combine with `oak-dev ci context` for richer understanding
 
 ## Output
 
@@ -131,8 +131,8 @@ Results include:
 
 ```bash
 # JSON output (default) - good for parsing
-oak ci search "database transactions" -f json
+oak-dev ci search "database transactions" -f json
 
 # Text output - good for reading
-oak ci search "database transactions" -f text
+oak-dev ci search "database transactions" -f text
 ```

--- a/.cursor/skills/codebase-intelligence/references/impact-analysis.md
+++ b/.cursor/skills/codebase-intelligence/references/impact-analysis.md
@@ -22,23 +22,23 @@ Semantic search finds code related by meaning. When you change how something wor
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 
 # Search for code using similar patterns
-oak ci search "code that depends on JWT token format" --type code
+oak-dev ci search "code that depends on JWT token format" --type code
 ```
 
 ### Check for related memories
 
 ```bash
 # Find past learnings that might be relevant
-oak ci search "gotchas with auth changes" --type memory
+oak-dev ci search "gotchas with auth changes" --type memory
 
 # Find decisions that might be affected
-oak ci search "decisions about token handling"
+oak-dev ci search "decisions about token handling"
 ```
 
 ## Example: Before Refactoring
@@ -47,16 +47,16 @@ oak ci search "decisions about token handling"
 
 ```bash
 # 1. Find all code conceptually related to payment processing
-oak ci search "payment processing flow" --type code -n 20
+oak-dev ci search "payment processing flow" --type code -n 20
 
 # 2. Find code that handles payment errors (often missed)
-oak ci search "payment error handling and recovery" --type code
+oak-dev ci search "payment error handling and recovery" --type code
 
 # 3. Find related integrations
-oak ci search "payment gateway integration" --type code
+oak-dev ci search "payment gateway integration" --type code
 
 # 4. Check for past issues/decisions
-oak ci search "payment processing gotchas" --type memory
+oak-dev ci search "payment processing gotchas" --type memory
 ```
 
 **What you'll find**:
@@ -74,25 +74,25 @@ Many of these won't show up in import analysis!
 
 ```bash
 # Find all code that might parse this response
-oak ci search "user API response handling" --type code
+oak-dev ci search "user API response handling" --type code
 
 # Find frontend code consuming this API
-oak ci search "fetch user data from API" --type code
+oak-dev ci search "fetch user data from API" --type code
 
 # Find tests that might break
-oak ci search "user API endpoint tests" --type code
+oak-dev ci search "user API endpoint tests" --type code
 
 # Check for integration patterns
-oak ci context "code that depends on user API format"
+oak-dev ci context "code that depends on user API format"
 ```
 
 ## Impact Analysis Workflow
 
 1. **Identify the change**: What are you modifying?
-2. **Search for direct usage**: `oak ci search "ComponentName" --type code`
-3. **Search for conceptual usage**: `oak ci search "what ComponentName does" --type code`
-4. **Check for patterns**: `oak ci search "code using similar patterns" --type code`
-5. **Review memories**: `oak ci search "past issues with this area" --type memory`
+2. **Search for direct usage**: `oak-dev ci search "ComponentName" --type code`
+3. **Search for conceptual usage**: `oak-dev ci search "what ComponentName does" --type code`
+4. **Check for patterns**: `oak-dev ci search "code using similar patterns" --type code`
+5. **Review memories**: `oak-dev ci search "past issues with this area" --type memory`
 6. **Read the results**: Assess which code might need updates
 
 ## Tips
@@ -101,4 +101,4 @@ oak ci context "code that depends on user API format"
 - Search for what the code *does*, not just its name
 - Include error handling and edge cases in your search
 - Check memories for past issues in this area
-- Use `oak ci context` with the file you're changing for focused results
+- Use `oak-dev ci context` with the file you're changing for focused results

--- a/.cursor/skills/codebase-intelligence/references/querying-databases.md
+++ b/.cursor/skills/codebase-intelligence/references/querying-databases.md
@@ -19,7 +19,7 @@ Use direct SQL when browsing the dashboard is insufficient and detailed analysis
 - Full-text keyword search (FTS5 `MATCH` — different from semantic vector search)
 - When the CI daemon is not running (SQLite is always readable directly)
 
-**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak ci remember`.
+**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak-dev ci remember`.
 
 ## Database Location
 
@@ -69,13 +69,13 @@ For everyday codebase intelligence (semantic search, storing memories, retrievin
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search (code, memories, plans) |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory or learning |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
-| — | `oak ci memories --type gotcha` | Browse memories by type |
-| — | `oak ci sessions` | List session summaries |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search (code, memories, plans) |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory or learning |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
+| — | `oak-dev ci memories --type gotcha` | Browse memories by type |
+| — | `oak-dev ci sessions` | List session summaries |
 
-Check daemon status with `oak ci status`. Start with `oak ci start` if needed.
+Check daemon status with `oak-dev ci status`. Start with `oak-dev ci start` if needed.
 
 ## Important Notes
 
@@ -99,10 +99,10 @@ For complete schema DDL and advanced query patterns, consult:
 For automated analysis that runs these queries and produces reports, use the analysis agent:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.cursor/skills/project-governance/SKILL.md
+++ b/.cursor/skills/project-governance/SKILL.md
@@ -26,16 +26,16 @@ Create, modify, and maintain project constitutions, agent instruction files, and
 ### Create an RFC
 
 ```bash
-oak rfc create --title "Add caching layer" --template feature
-oak rfc list
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc create --title "Add caching layer" --template feature
+oak-dev rfc list
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ### Sync agent instruction files
 
 ```bash
-oak rules sync-agents          # Sync constitution references to all agent files
-oak rules detect-existing      # Discover all configured agent instruction files
+oak-dev rules sync-agents          # Sync constitution references to all agent files
+oak-dev rules detect-existing      # Discover all configured agent instruction files
 ```
 
 ## Commands Reference
@@ -44,21 +44,21 @@ oak rules detect-existing      # Discover all configured agent instruction files
 
 | Command | Purpose |
 |---------|---------|
-| `oak rules sync-agents` | Sync constitution references to all agent instruction files |
-| `oak rules sync-agents --dry-run` | Preview what files will be checked/updated |
-| `oak rules detect-existing` | Discover all configured agent instruction files |
-| `oak rules detect-existing --json` | Machine-readable output of agent files |
+| `oak-dev rules sync-agents` | Sync constitution references to all agent instruction files |
+| `oak-dev rules sync-agents --dry-run` | Preview what files will be checked/updated |
+| `oak-dev rules detect-existing` | Discover all configured agent instruction files |
+| `oak-dev rules detect-existing --json` | Machine-readable output of agent files |
 
 ### RFC commands
 
 | Command | Purpose |
 |---------|---------|
-| `oak rfc create --title "..." --template <type>` | Create a new RFC |
-| `oak rfc list` | List all RFCs |
-| `oak rfc validate <path>` | Validate RFC structure and content |
-| `oak rfc show <path>` | Show RFC details |
-| `oak rfc adopt <path>` | Mark RFC as adopted |
-| `oak rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
+| `oak-dev rfc create --title "..." --template <type>` | Create a new RFC |
+| `oak-dev rfc list` | List all RFCs |
+| `oak-dev rfc validate <path>` | Validate RFC structure and content |
+| `oak-dev rfc show <path>` | Show RFC details |
+| `oak-dev rfc adopt <path>` | Mark RFC as adopted |
+| `oak-dev rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
 
 ## When to Use
 
@@ -98,16 +98,16 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 
 1. **Read** the current constitution (`oak/constitution.md`)
 2. **Add** the full rule to the appropriate section using RFC 2119 language (MUST, SHOULD, MAY)
-3. **Sync** to all agent files: `oak rules sync-agents`
+3. **Sync** to all agent files: `oak-dev rules sync-agents`
 
 **CRITICAL:** Rules MUST be added to the constitution FIRST, then synced to agent files. Never add a rule only to an agent file.
 
 ### RFC lifecycle
 
-1. **Create**: `oak rfc create --title "..." --template feature --author "Name"`
+1. **Create**: `oak-dev rfc create --title "..." --template feature --author "Name"`
 2. **Fill in**: Problem context, proposed solution, trade-offs, alternatives
 3. **Review**: Use the review checklist (see `references/reviewing-rfcs.md`)
-4. **Adopt or abandon**: `oak rfc adopt <path>` or `oak rfc abandon <path> --reason "..."`
+4. **Adopt or abandon**: `oak-dev rfc adopt <path>` or `oak-dev rfc abandon <path> --reason "..."`
 
 ### RFC review checklist (summary)
 
@@ -131,7 +131,7 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 ## Files
 
 - Constitution: `oak/constitution.md` or `.constitution.md`
-- Agent files: Run `oak rules detect-existing` to discover all agent instruction files
+- Agent files: Run `oak-dev rules detect-existing` to discover all agent instruction files
 - RFCs: `oak/rfc/RFC-XXX-short-title.md`
 
 ## Deep Dives

--- a/.cursor/skills/project-governance/references/agent-files-guide.md
+++ b/.cursor/skills/project-governance/references/agent-files-guide.md
@@ -15,7 +15,7 @@ Agent instruction files are **short, operational documents** that:
 ### Option 1: Use OAK's sync command
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ### Option 2: Create manually
@@ -65,8 +65,8 @@ Do NOT hardcode agent file names. Use OAK's built-in commands:
 
 ```bash
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 Agent files are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -77,10 +77,10 @@ When the constitution is updated, sync changes to all agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## What Makes a Good Agent File

--- a/.cursor/skills/project-governance/references/constitution-guide.md
+++ b/.cursor/skills/project-governance/references/constitution-guide.md
@@ -116,7 +116,7 @@ Create `oak/constitution.md` (or `.constitution.md` at root):
 After creating the constitution, create agent files that reference it:
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## Adding Rules to Existing Constitution
@@ -130,8 +130,8 @@ oak rules sync-agents
 cat oak/constitution.md  # or .constitution.md
 
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 **Do NOT hardcode agent file names.** Agents are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -168,13 +168,13 @@ After the constitution is updated, sync to all configured agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
-If manual updates are needed, use `oak rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
+If manual updates are needed, use `oak-dev rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
 
 ```markdown
 ## [Rule Name]
@@ -182,7 +182,7 @@ If manual updates are needed, use `oak rules detect-existing --json` to get the 
 **MUST NOT** [brief prohibition]. See §[section] of `oak/constitution.md` for the full rule, rationale, and verification command.
 ```
 
-**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak rules detect-existing`.
+**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak-dev rules detect-existing`.
 
 ## Example Workflow
 
@@ -196,4 +196,4 @@ User: "We need to establish coding standards for this Python project"
    - Quality gate (`make check` or equivalent)
    - Anchor files (point to best existing modules)
 3. **Create agent files** referencing the constitution
-4. **Sync**: `oak rules sync-agents`
+4. **Sync**: `oak-dev rules sync-agents`

--- a/.cursor/skills/project-governance/references/creating-rfcs.md
+++ b/.cursor/skills/project-governance/references/creating-rfcs.md
@@ -22,13 +22,13 @@ Use this workflow when:
 
 ```bash
 # Create an RFC interactively
-oak rfc create --title "Add caching layer" --template feature
+oak-dev rfc create --title "Add caching layer" --template feature
 
 # List existing RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate an RFC
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ## RFC Templates
@@ -70,7 +70,7 @@ What else did we consider? Why not those?
 ### 1. Create the RFC
 
 ```bash
-oak rfc create --title "Your RFC Title" --template feature --author "Your Name"
+oak-dev rfc create --title "Your RFC Title" --template feature --author "Your Name"
 ```
 
 This creates a file in `oak/rfc/` with the proper structure.
@@ -88,13 +88,13 @@ Edit the generated file to add:
 The RFC is now ready for team review. Once approved:
 
 ```bash
-oak rfc adopt oak/rfc/RFC-XXX-your-rfc.md
+oak-dev rfc adopt oak/rfc/RFC-XXX-your-rfc.md
 ```
 
 Or if abandoned:
 
 ```bash
-oak rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
+oak-dev rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
 ```
 
 ## Tips

--- a/.cursor/skills/project-governance/references/reviewing-rfcs.md
+++ b/.cursor/skills/project-governance/references/reviewing-rfcs.md
@@ -21,13 +21,13 @@ Use this workflow when:
 
 ```bash
 # List all RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate a specific RFC
-oak rfc validate oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc validate oak/rfc/RFC-001-your-rfc.md
 
 # Show RFC details
-oak rfc show oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc show oak/rfc/RFC-001-your-rfc.md
 ```
 
 ## Review Checklist
@@ -88,7 +88,7 @@ When providing feedback, structure it as:
 Run automated validation:
 
 ```bash
-oak rfc validate oak/rfc/RFC-XXX-title.md
+oak-dev rfc validate oak/rfc/RFC-XXX-title.md
 ```
 
 This checks:
@@ -111,5 +111,5 @@ This checks:
 RFCs are in `oak/rfc/` directory. List all with:
 
 ```bash
-oak rfc list
+oak-dev rfc list
 ```

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,6 +1,7 @@
 {
   "coreTools": [
-    "ShellTool(oak *)"
+    "ShellTool(oak *)",
+    "ShellTool(oak-dev *)"
   ],
   "hooks": {
     "SessionStart": [
@@ -10,7 +11,7 @@
           {
             "name": "oak-ci-context",
             "type": "command",
-            "command": "oak ci hook SessionStart --agent gemini",
+            "command": "oak-dev ci hook SessionStart --agent gemini",
             "timeout": 60000
           }
         ]
@@ -23,7 +24,7 @@
           {
             "name": "oak-ci-prompt",
             "type": "command",
-            "command": "oak ci hook BeforeAgent --agent gemini",
+            "command": "oak-dev ci hook BeforeAgent --agent gemini",
             "timeout": 15000
           }
         ]
@@ -36,7 +37,7 @@
           {
             "name": "oak-ci-observe",
             "type": "command",
-            "command": "oak ci hook PostToolUse --agent gemini",
+            "command": "oak-dev ci hook PostToolUse --agent gemini",
             "timeout": 15000
           }
         ]
@@ -49,7 +50,7 @@
           {
             "name": "oak-ci-stop",
             "type": "command",
-            "command": "oak ci hook AfterAgent --agent gemini",
+            "command": "oak-dev ci hook AfterAgent --agent gemini",
             "timeout": 15000
           }
         ]
@@ -62,7 +63,7 @@
           {
             "name": "oak-ci-pre-compact",
             "type": "command",
-            "command": "oak ci hook PreCompress --agent gemini",
+            "command": "oak-dev ci hook PreCompress --agent gemini",
             "timeout": 15000
           }
         ]
@@ -75,7 +76,7 @@
           {
             "name": "oak-ci-session-end",
             "type": "command",
-            "command": "oak ci hook SessionEnd --agent gemini",
+            "command": "oak-dev ci hook SessionEnd --agent gemini",
             "timeout": 15000
           }
         ]
@@ -84,7 +85,7 @@
   },
   "mcpServers": {
     "oak-ci": {
-      "command": "oak",
+      "command": "oak-dev",
       "args": [
         "ci",
         "mcp"

--- a/.gemini/skills/codebase-intelligence/SKILL.md
+++ b/.gemini/skills/codebase-intelligence/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   in previous sessions, looking up past conversations or outcomes, querying
   session history, checking activity logs, browsing memories, running SQL
   against activities.db, or exploring patterns that grep would miss. Do NOT use
-  for storing memories — use oak_remember or oak ci remember instead.
+  for storing memories — use oak_remember or oak-dev ci remember instead.
 allowed-tools: Bash, Read
 user-invocable: true
 ---
@@ -23,20 +23,20 @@ Search, analyze, and query your codebase using semantic vector search, impact an
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 ```
 
 ### Impact analysis
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 ```
 
 ### Session and memory lookup
@@ -47,10 +47,10 @@ sqlite3 -readonly -header -column .oak/ci/activities.db \
   "SELECT id, agent, title, status, datetime(created_at_epoch, 'unixepoch', 'localtime') as started FROM sessions ORDER BY created_at_epoch DESC LIMIT 5;"
 
 # Search past decisions and learnings
-oak ci search "authentication refactor decision" --type memory
+oak-dev ci search "authentication refactor decision" --type memory
 
 # Browse memories by type
-oak ci memories --type decision
+oak-dev ci memories --type decision
 ```
 
 ### Database query
@@ -66,22 +66,22 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "SELECT count(*) FROM se
 
 | Command | Purpose |
 |---------|---------|
-| `oak ci search "query" --type code` | Semantic vector search for code |
-| `oak ci search "query" --type memory` | Semantic search for memories |
-| `oak ci search "query" -n 20` | Broader search with more results |
-| `oak ci context "task" -f <file>` | Get context for current work |
-| `oak ci remember "observation"` | Store a memory (NOT via SQL) |
-| `oak ci memories --type gotcha` | Browse memories by type |
-| `oak ci sessions` | List session summaries |
-| `oak ci status` | Check daemon status |
+| `oak-dev ci search "query" --type code` | Semantic vector search for code |
+| `oak-dev ci search "query" --type memory` | Semantic search for memories |
+| `oak-dev ci search "query" -n 20` | Broader search with more results |
+| `oak-dev ci context "task" -f <file>` | Get context for current work |
+| `oak-dev ci remember "observation"` | Store a memory (NOT via SQL) |
+| `oak-dev ci memories --type gotcha` | Browse memories by type |
+| `oak-dev ci sessions` | List session summaries |
+| `oak-dev ci status` | Check daemon status |
 
 ### MCP tools
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
 
 ### Direct SQL
 
@@ -93,15 +93,15 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 
 | Need | Tool | Example |
 |------|------|---------|
-| Find similar implementations | `oak ci search --type code` | "retry with exponential backoff" |
-| Understand component relationships | `oak ci context` | "how auth middleware relates to session handling" |
-| Assess refactoring risk | `oak ci search --type code -n 20` | "PaymentProcessor error handling" |
-| Find past decisions/gotchas | `oak ci search --type memory` | "gotchas with auth changes" |
+| Find similar implementations | `oak-dev ci search --type code` | "retry with exponential backoff" |
+| Understand component relationships | `oak-dev ci context` | "how auth middleware relates to session handling" |
+| Assess refactoring risk | `oak-dev ci search --type code -n 20` | "PaymentProcessor error handling" |
+| Find past decisions/gotchas | `oak-dev ci search --type memory` | "gotchas with auth changes" |
 | Recall previous discussions | `sqlite3 -readonly` | `SELECT title, summary FROM sessions WHERE ...` |
-| Find what was done before | `oak ci memories` / `sqlite3` | "what did we decide about caching?" |
+| Find what was done before | `oak-dev ci memories` / `sqlite3` | "what did we decide about caching?" |
 | Query session history | `sqlite3 -readonly` | `SELECT * FROM sessions ORDER BY ...` |
 | Aggregate usage stats | `sqlite3 -readonly` | `SELECT agent_name, sum(cost_usd) FROM agent_runs ...` |
-| Run automated analysis | `oak ci agent run` | `oak ci agent run usage-report` |
+| Run automated analysis | `oak-dev ci agent run` | `oak-dev ci agent run usage-report` |
 
 ## Why Semantic Search Over Grep
 
@@ -217,10 +217,10 @@ ORDER BY next_run_at_epoch;
 For automated analysis that runs queries and produces reports:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.gemini/skills/codebase-intelligence/references/analysis-playbooks.md
+++ b/.gemini/skills/codebase-intelligence/references/analysis-playbooks.md
@@ -2,7 +2,7 @@
 
 Structured multi-query workflows for analyzing CI data. Each playbook is a sequence of queries that build on each other to answer a specific question.
 
-These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak ci agent run <task-name>`).
+These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak-dev ci agent run <task-name>`).
 
 ## Playbook 1: Usage & Cost Analysis
 
@@ -223,10 +223,10 @@ LIMIT 10;
 These playbooks can be run automatically via the analysis agent:
 
 ```bash
-oak ci agent run usage-report          # Playbook 1
-oak ci agent run productivity-report   # Playbook 2
-oak ci agent run codebase-activity-report  # Playbook 3
-oak ci agent run prompt-analysis       # Playbook 4
+oak-dev ci agent run usage-report          # Playbook 1
+oak-dev ci agent run productivity-report   # Playbook 2
+oak-dev ci agent run codebase-activity-report  # Playbook 3
+oak-dev ci agent run prompt-analysis       # Playbook 4
 ```
 
 Reports are written to `oak/insights/` and can be committed to git for team visibility.

--- a/.gemini/skills/codebase-intelligence/references/finding-related-code.md
+++ b/.gemini/skills/codebase-intelligence/references/finding-related-code.md
@@ -29,39 +29,39 @@ Use this workflow when:
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 
 # More results for broader exploration
-oak ci search "error handling and logging" --type code -n 20
+oak-dev ci search "error handling and logging" --type code -n 20
 ```
 
 ### Discover component relationships
 
 ```bash
 # Find code related to two concepts (relationship)
-oak ci search "how does AuthService interact with TokenManager"
+oak-dev ci search "how does AuthService interact with TokenManager"
 
 # Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 
 # Get context about a specific relationship
-oak ci context "relationship between UserService and PaymentProcessor"
+oak-dev ci context "relationship between UserService and PaymentProcessor"
 ```
 
 ### Get context for current work
 
 ```bash
 # Find code related to files you're editing
-oak ci context "similar implementations" -f src/services/user.py
+oak-dev ci context "similar implementations" -f src/services/user.py
 
 # Find related code for a specific task
-oak ci context "validation patterns" -f src/api/handlers.py
+oak-dev ci context "validation patterns" -f src/api/handlers.py
 
 # Get context with specific files in focus
-oak ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
+oak-dev ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
 ```
 
 ## Example: Finding Similar Implementations
@@ -70,13 +70,13 @@ oak ci context "how auth middleware relates to session handling" -f src/middlewa
 
 ```bash
 # 1. Find existing endpoint implementations
-oak ci search "REST API endpoint handler" --type code
+oak-dev ci search "REST API endpoint handler" --type code
 
 # 2. Find validation patterns
-oak ci search "input validation for API requests" --type code
+oak-dev ci search "input validation for API requests" --type code
 
 # 3. Find error handling patterns
-oak ci search "API error response formatting" --type code
+oak-dev ci search "API error response formatting" --type code
 ```
 
 **What you'll find**: Consistent patterns used elsewhere, even if the endpoints are in different modules or use different naming conventions.
@@ -92,7 +92,7 @@ oak ci search "API error response formatting" --type code
 # - "token_refresh" (authentication adjacent)
 
 # Semantic search finds them all:
-oak ci search "user authentication and authorization" --type code -n 20
+oak-dev ci search "user authentication and authorization" --type code -n 20
 ```
 
 ## Example: Understanding Component Relationships
@@ -101,13 +101,13 @@ oak ci search "user authentication and authorization" --type code -n 20
 
 ```bash
 # 1. Search for code mentioning both concepts
-oak ci search "OrderService inventory management"
+oak-dev ci search "OrderService inventory management"
 
 # 2. Get broader context
-oak ci context "relationship between orders and inventory"
+oak-dev ci context "relationship between orders and inventory"
 
 # 3. Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 ```
 
 **What you'll find**: Semantic search reveals event handlers, shared models, and integration points that aren't obvious from imports alone.
@@ -120,7 +120,7 @@ oak ci search "order creation inventory update"
 - Increase `-n` limit when exploring broadly
 - Use `--type code` to focus on implementation (exclude memories)
 - Combine multiple searches to build complete picture
-- Combine with `oak ci context` for richer understanding
+- Combine with `oak-dev ci context` for richer understanding
 
 ## Output
 
@@ -131,8 +131,8 @@ Results include:
 
 ```bash
 # JSON output (default) - good for parsing
-oak ci search "database transactions" -f json
+oak-dev ci search "database transactions" -f json
 
 # Text output - good for reading
-oak ci search "database transactions" -f text
+oak-dev ci search "database transactions" -f text
 ```

--- a/.gemini/skills/codebase-intelligence/references/impact-analysis.md
+++ b/.gemini/skills/codebase-intelligence/references/impact-analysis.md
@@ -22,23 +22,23 @@ Semantic search finds code related by meaning. When you change how something wor
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 
 # Search for code using similar patterns
-oak ci search "code that depends on JWT token format" --type code
+oak-dev ci search "code that depends on JWT token format" --type code
 ```
 
 ### Check for related memories
 
 ```bash
 # Find past learnings that might be relevant
-oak ci search "gotchas with auth changes" --type memory
+oak-dev ci search "gotchas with auth changes" --type memory
 
 # Find decisions that might be affected
-oak ci search "decisions about token handling"
+oak-dev ci search "decisions about token handling"
 ```
 
 ## Example: Before Refactoring
@@ -47,16 +47,16 @@ oak ci search "decisions about token handling"
 
 ```bash
 # 1. Find all code conceptually related to payment processing
-oak ci search "payment processing flow" --type code -n 20
+oak-dev ci search "payment processing flow" --type code -n 20
 
 # 2. Find code that handles payment errors (often missed)
-oak ci search "payment error handling and recovery" --type code
+oak-dev ci search "payment error handling and recovery" --type code
 
 # 3. Find related integrations
-oak ci search "payment gateway integration" --type code
+oak-dev ci search "payment gateway integration" --type code
 
 # 4. Check for past issues/decisions
-oak ci search "payment processing gotchas" --type memory
+oak-dev ci search "payment processing gotchas" --type memory
 ```
 
 **What you'll find**:
@@ -74,25 +74,25 @@ Many of these won't show up in import analysis!
 
 ```bash
 # Find all code that might parse this response
-oak ci search "user API response handling" --type code
+oak-dev ci search "user API response handling" --type code
 
 # Find frontend code consuming this API
-oak ci search "fetch user data from API" --type code
+oak-dev ci search "fetch user data from API" --type code
 
 # Find tests that might break
-oak ci search "user API endpoint tests" --type code
+oak-dev ci search "user API endpoint tests" --type code
 
 # Check for integration patterns
-oak ci context "code that depends on user API format"
+oak-dev ci context "code that depends on user API format"
 ```
 
 ## Impact Analysis Workflow
 
 1. **Identify the change**: What are you modifying?
-2. **Search for direct usage**: `oak ci search "ComponentName" --type code`
-3. **Search for conceptual usage**: `oak ci search "what ComponentName does" --type code`
-4. **Check for patterns**: `oak ci search "code using similar patterns" --type code`
-5. **Review memories**: `oak ci search "past issues with this area" --type memory`
+2. **Search for direct usage**: `oak-dev ci search "ComponentName" --type code`
+3. **Search for conceptual usage**: `oak-dev ci search "what ComponentName does" --type code`
+4. **Check for patterns**: `oak-dev ci search "code using similar patterns" --type code`
+5. **Review memories**: `oak-dev ci search "past issues with this area" --type memory`
 6. **Read the results**: Assess which code might need updates
 
 ## Tips
@@ -101,4 +101,4 @@ oak ci context "code that depends on user API format"
 - Search for what the code *does*, not just its name
 - Include error handling and edge cases in your search
 - Check memories for past issues in this area
-- Use `oak ci context` with the file you're changing for focused results
+- Use `oak-dev ci context` with the file you're changing for focused results

--- a/.gemini/skills/codebase-intelligence/references/querying-databases.md
+++ b/.gemini/skills/codebase-intelligence/references/querying-databases.md
@@ -19,7 +19,7 @@ Use direct SQL when browsing the dashboard is insufficient and detailed analysis
 - Full-text keyword search (FTS5 `MATCH` — different from semantic vector search)
 - When the CI daemon is not running (SQLite is always readable directly)
 
-**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak ci remember`.
+**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak-dev ci remember`.
 
 ## Database Location
 
@@ -69,13 +69,13 @@ For everyday codebase intelligence (semantic search, storing memories, retrievin
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search (code, memories, plans) |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory or learning |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
-| — | `oak ci memories --type gotcha` | Browse memories by type |
-| — | `oak ci sessions` | List session summaries |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search (code, memories, plans) |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory or learning |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
+| — | `oak-dev ci memories --type gotcha` | Browse memories by type |
+| — | `oak-dev ci sessions` | List session summaries |
 
-Check daemon status with `oak ci status`. Start with `oak ci start` if needed.
+Check daemon status with `oak-dev ci status`. Start with `oak-dev ci start` if needed.
 
 ## Important Notes
 
@@ -99,10 +99,10 @@ For complete schema DDL and advanced query patterns, consult:
 For automated analysis that runs these queries and produces reports, use the analysis agent:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.gemini/skills/project-governance/SKILL.md
+++ b/.gemini/skills/project-governance/SKILL.md
@@ -26,16 +26,16 @@ Create, modify, and maintain project constitutions, agent instruction files, and
 ### Create an RFC
 
 ```bash
-oak rfc create --title "Add caching layer" --template feature
-oak rfc list
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc create --title "Add caching layer" --template feature
+oak-dev rfc list
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ### Sync agent instruction files
 
 ```bash
-oak rules sync-agents          # Sync constitution references to all agent files
-oak rules detect-existing      # Discover all configured agent instruction files
+oak-dev rules sync-agents          # Sync constitution references to all agent files
+oak-dev rules detect-existing      # Discover all configured agent instruction files
 ```
 
 ## Commands Reference
@@ -44,21 +44,21 @@ oak rules detect-existing      # Discover all configured agent instruction files
 
 | Command | Purpose |
 |---------|---------|
-| `oak rules sync-agents` | Sync constitution references to all agent instruction files |
-| `oak rules sync-agents --dry-run` | Preview what files will be checked/updated |
-| `oak rules detect-existing` | Discover all configured agent instruction files |
-| `oak rules detect-existing --json` | Machine-readable output of agent files |
+| `oak-dev rules sync-agents` | Sync constitution references to all agent instruction files |
+| `oak-dev rules sync-agents --dry-run` | Preview what files will be checked/updated |
+| `oak-dev rules detect-existing` | Discover all configured agent instruction files |
+| `oak-dev rules detect-existing --json` | Machine-readable output of agent files |
 
 ### RFC commands
 
 | Command | Purpose |
 |---------|---------|
-| `oak rfc create --title "..." --template <type>` | Create a new RFC |
-| `oak rfc list` | List all RFCs |
-| `oak rfc validate <path>` | Validate RFC structure and content |
-| `oak rfc show <path>` | Show RFC details |
-| `oak rfc adopt <path>` | Mark RFC as adopted |
-| `oak rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
+| `oak-dev rfc create --title "..." --template <type>` | Create a new RFC |
+| `oak-dev rfc list` | List all RFCs |
+| `oak-dev rfc validate <path>` | Validate RFC structure and content |
+| `oak-dev rfc show <path>` | Show RFC details |
+| `oak-dev rfc adopt <path>` | Mark RFC as adopted |
+| `oak-dev rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
 
 ## When to Use
 
@@ -98,16 +98,16 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 
 1. **Read** the current constitution (`oak/constitution.md`)
 2. **Add** the full rule to the appropriate section using RFC 2119 language (MUST, SHOULD, MAY)
-3. **Sync** to all agent files: `oak rules sync-agents`
+3. **Sync** to all agent files: `oak-dev rules sync-agents`
 
 **CRITICAL:** Rules MUST be added to the constitution FIRST, then synced to agent files. Never add a rule only to an agent file.
 
 ### RFC lifecycle
 
-1. **Create**: `oak rfc create --title "..." --template feature --author "Name"`
+1. **Create**: `oak-dev rfc create --title "..." --template feature --author "Name"`
 2. **Fill in**: Problem context, proposed solution, trade-offs, alternatives
 3. **Review**: Use the review checklist (see `references/reviewing-rfcs.md`)
-4. **Adopt or abandon**: `oak rfc adopt <path>` or `oak rfc abandon <path> --reason "..."`
+4. **Adopt or abandon**: `oak-dev rfc adopt <path>` or `oak-dev rfc abandon <path> --reason "..."`
 
 ### RFC review checklist (summary)
 
@@ -131,7 +131,7 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 ## Files
 
 - Constitution: `oak/constitution.md` or `.constitution.md`
-- Agent files: Run `oak rules detect-existing` to discover all agent instruction files
+- Agent files: Run `oak-dev rules detect-existing` to discover all agent instruction files
 - RFCs: `oak/rfc/RFC-XXX-short-title.md`
 
 ## Deep Dives

--- a/.gemini/skills/project-governance/references/agent-files-guide.md
+++ b/.gemini/skills/project-governance/references/agent-files-guide.md
@@ -15,7 +15,7 @@ Agent instruction files are **short, operational documents** that:
 ### Option 1: Use OAK's sync command
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ### Option 2: Create manually
@@ -65,8 +65,8 @@ Do NOT hardcode agent file names. Use OAK's built-in commands:
 
 ```bash
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 Agent files are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -77,10 +77,10 @@ When the constitution is updated, sync changes to all agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## What Makes a Good Agent File

--- a/.gemini/skills/project-governance/references/constitution-guide.md
+++ b/.gemini/skills/project-governance/references/constitution-guide.md
@@ -116,7 +116,7 @@ Create `oak/constitution.md` (or `.constitution.md` at root):
 After creating the constitution, create agent files that reference it:
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## Adding Rules to Existing Constitution
@@ -130,8 +130,8 @@ oak rules sync-agents
 cat oak/constitution.md  # or .constitution.md
 
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 **Do NOT hardcode agent file names.** Agents are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -168,13 +168,13 @@ After the constitution is updated, sync to all configured agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
-If manual updates are needed, use `oak rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
+If manual updates are needed, use `oak-dev rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
 
 ```markdown
 ## [Rule Name]
@@ -182,7 +182,7 @@ If manual updates are needed, use `oak rules detect-existing --json` to get the 
 **MUST NOT** [brief prohibition]. See §[section] of `oak/constitution.md` for the full rule, rationale, and verification command.
 ```
 
-**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak rules detect-existing`.
+**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak-dev rules detect-existing`.
 
 ## Example Workflow
 
@@ -196,4 +196,4 @@ User: "We need to establish coding standards for this Python project"
    - Quality gate (`make check` or equivalent)
    - Anchor files (point to best existing modules)
 3. **Create agent files** referencing the constitution
-4. **Sync**: `oak rules sync-agents`
+4. **Sync**: `oak-dev rules sync-agents`

--- a/.gemini/skills/project-governance/references/creating-rfcs.md
+++ b/.gemini/skills/project-governance/references/creating-rfcs.md
@@ -22,13 +22,13 @@ Use this workflow when:
 
 ```bash
 # Create an RFC interactively
-oak rfc create --title "Add caching layer" --template feature
+oak-dev rfc create --title "Add caching layer" --template feature
 
 # List existing RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate an RFC
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ## RFC Templates
@@ -70,7 +70,7 @@ What else did we consider? Why not those?
 ### 1. Create the RFC
 
 ```bash
-oak rfc create --title "Your RFC Title" --template feature --author "Your Name"
+oak-dev rfc create --title "Your RFC Title" --template feature --author "Your Name"
 ```
 
 This creates a file in `oak/rfc/` with the proper structure.
@@ -88,13 +88,13 @@ Edit the generated file to add:
 The RFC is now ready for team review. Once approved:
 
 ```bash
-oak rfc adopt oak/rfc/RFC-XXX-your-rfc.md
+oak-dev rfc adopt oak/rfc/RFC-XXX-your-rfc.md
 ```
 
 Or if abandoned:
 
 ```bash
-oak rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
+oak-dev rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
 ```
 
 ## Tips

--- a/.gemini/skills/project-governance/references/reviewing-rfcs.md
+++ b/.gemini/skills/project-governance/references/reviewing-rfcs.md
@@ -21,13 +21,13 @@ Use this workflow when:
 
 ```bash
 # List all RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate a specific RFC
-oak rfc validate oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc validate oak/rfc/RFC-001-your-rfc.md
 
 # Show RFC details
-oak rfc show oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc show oak/rfc/RFC-001-your-rfc.md
 ```
 
 ## Review Checklist
@@ -88,7 +88,7 @@ When providing feedback, structure it as:
 Run automated validation:
 
 ```bash
-oak rfc validate oak/rfc/RFC-XXX-title.md
+oak-dev rfc validate oak/rfc/RFC-XXX-title.md
 ```
 
 This checks:
@@ -111,5 +111,5 @@ This checks:
 RFCs are in `oak/rfc/` directory. List all with:
 
 ```bash
-oak rfc list
+oak-dev rfc list
 ```

--- a/.github/hooks/oak-ci-hooks.json
+++ b/.github/hooks/oak-ci-hooks.json
@@ -4,40 +4,40 @@
     "sessionStart": [
       {
         "type": "command",
-        "bash": "oak ci hook sessionStart --agent copilot",
-        "powershell": "oak ci hook sessionStart --agent copilot",
+        "bash": "oak-dev ci hook sessionStart --agent copilot",
+        "powershell": "oak-dev ci hook sessionStart --agent copilot",
         "timeoutSec": 60
       }
     ],
     "sessionEnd": [
       {
         "type": "command",
-        "bash": "oak ci hook sessionEnd --agent copilot",
-        "powershell": "oak ci hook sessionEnd --agent copilot",
+        "bash": "oak-dev ci hook sessionEnd --agent copilot",
+        "powershell": "oak-dev ci hook sessionEnd --agent copilot",
         "timeoutSec": 60
       }
     ],
     "userPromptSubmitted": [
       {
         "type": "command",
-        "bash": "oak ci hook userPromptSubmitted --agent copilot",
-        "powershell": "oak ci hook userPromptSubmitted --agent copilot",
+        "bash": "oak-dev ci hook userPromptSubmitted --agent copilot",
+        "powershell": "oak-dev ci hook userPromptSubmitted --agent copilot",
         "timeoutSec": 60
       }
     ],
     "postToolUse": [
       {
         "type": "command",
-        "bash": "oak ci hook postToolUse --agent copilot",
-        "powershell": "oak ci hook postToolUse --agent copilot",
+        "bash": "oak-dev ci hook postToolUse --agent copilot",
+        "powershell": "oak-dev ci hook postToolUse --agent copilot",
         "timeoutSec": 60
       }
     ],
     "errorOccurred": [
       {
         "type": "command",
-        "bash": "oak ci hook errorOccurred --agent copilot",
-        "powershell": "oak ci hook errorOccurred --agent copilot",
+        "bash": "oak-dev ci hook errorOccurred --agent copilot",
+        "powershell": "oak-dev ci hook errorOccurred --agent copilot",
         "timeoutSec": 60,
         "comment": "Maps to post-tool-use-failure endpoint"
       }

--- a/.github/skills/codebase-intelligence/SKILL.md
+++ b/.github/skills/codebase-intelligence/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   in previous sessions, looking up past conversations or outcomes, querying
   session history, checking activity logs, browsing memories, running SQL
   against activities.db, or exploring patterns that grep would miss. Do NOT use
-  for storing memories — use oak_remember or oak ci remember instead.
+  for storing memories — use oak_remember or oak-dev ci remember instead.
 allowed-tools: Bash, Read
 user-invocable: true
 ---
@@ -23,20 +23,20 @@ Search, analyze, and query your codebase using semantic vector search, impact an
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 ```
 
 ### Impact analysis
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 ```
 
 ### Session and memory lookup
@@ -47,10 +47,10 @@ sqlite3 -readonly -header -column .oak/ci/activities.db \
   "SELECT id, agent, title, status, datetime(created_at_epoch, 'unixepoch', 'localtime') as started FROM sessions ORDER BY created_at_epoch DESC LIMIT 5;"
 
 # Search past decisions and learnings
-oak ci search "authentication refactor decision" --type memory
+oak-dev ci search "authentication refactor decision" --type memory
 
 # Browse memories by type
-oak ci memories --type decision
+oak-dev ci memories --type decision
 ```
 
 ### Database query
@@ -66,22 +66,22 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "SELECT count(*) FROM se
 
 | Command | Purpose |
 |---------|---------|
-| `oak ci search "query" --type code` | Semantic vector search for code |
-| `oak ci search "query" --type memory` | Semantic search for memories |
-| `oak ci search "query" -n 20` | Broader search with more results |
-| `oak ci context "task" -f <file>` | Get context for current work |
-| `oak ci remember "observation"` | Store a memory (NOT via SQL) |
-| `oak ci memories --type gotcha` | Browse memories by type |
-| `oak ci sessions` | List session summaries |
-| `oak ci status` | Check daemon status |
+| `oak-dev ci search "query" --type code` | Semantic vector search for code |
+| `oak-dev ci search "query" --type memory` | Semantic search for memories |
+| `oak-dev ci search "query" -n 20` | Broader search with more results |
+| `oak-dev ci context "task" -f <file>` | Get context for current work |
+| `oak-dev ci remember "observation"` | Store a memory (NOT via SQL) |
+| `oak-dev ci memories --type gotcha` | Browse memories by type |
+| `oak-dev ci sessions` | List session summaries |
+| `oak-dev ci status` | Check daemon status |
 
 ### MCP tools
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
 
 ### Direct SQL
 
@@ -93,15 +93,15 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 
 | Need | Tool | Example |
 |------|------|---------|
-| Find similar implementations | `oak ci search --type code` | "retry with exponential backoff" |
-| Understand component relationships | `oak ci context` | "how auth middleware relates to session handling" |
-| Assess refactoring risk | `oak ci search --type code -n 20` | "PaymentProcessor error handling" |
-| Find past decisions/gotchas | `oak ci search --type memory` | "gotchas with auth changes" |
+| Find similar implementations | `oak-dev ci search --type code` | "retry with exponential backoff" |
+| Understand component relationships | `oak-dev ci context` | "how auth middleware relates to session handling" |
+| Assess refactoring risk | `oak-dev ci search --type code -n 20` | "PaymentProcessor error handling" |
+| Find past decisions/gotchas | `oak-dev ci search --type memory` | "gotchas with auth changes" |
 | Recall previous discussions | `sqlite3 -readonly` | `SELECT title, summary FROM sessions WHERE ...` |
-| Find what was done before | `oak ci memories` / `sqlite3` | "what did we decide about caching?" |
+| Find what was done before | `oak-dev ci memories` / `sqlite3` | "what did we decide about caching?" |
 | Query session history | `sqlite3 -readonly` | `SELECT * FROM sessions ORDER BY ...` |
 | Aggregate usage stats | `sqlite3 -readonly` | `SELECT agent_name, sum(cost_usd) FROM agent_runs ...` |
-| Run automated analysis | `oak ci agent run` | `oak ci agent run usage-report` |
+| Run automated analysis | `oak-dev ci agent run` | `oak-dev ci agent run usage-report` |
 
 ## Why Semantic Search Over Grep
 
@@ -217,10 +217,10 @@ ORDER BY next_run_at_epoch;
 For automated analysis that runs queries and produces reports:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.github/skills/codebase-intelligence/references/analysis-playbooks.md
+++ b/.github/skills/codebase-intelligence/references/analysis-playbooks.md
@@ -2,7 +2,7 @@
 
 Structured multi-query workflows for analyzing CI data. Each playbook is a sequence of queries that build on each other to answer a specific question.
 
-These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak ci agent run <task-name>`).
+These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak-dev ci agent run <task-name>`).
 
 ## Playbook 1: Usage & Cost Analysis
 
@@ -223,10 +223,10 @@ LIMIT 10;
 These playbooks can be run automatically via the analysis agent:
 
 ```bash
-oak ci agent run usage-report          # Playbook 1
-oak ci agent run productivity-report   # Playbook 2
-oak ci agent run codebase-activity-report  # Playbook 3
-oak ci agent run prompt-analysis       # Playbook 4
+oak-dev ci agent run usage-report          # Playbook 1
+oak-dev ci agent run productivity-report   # Playbook 2
+oak-dev ci agent run codebase-activity-report  # Playbook 3
+oak-dev ci agent run prompt-analysis       # Playbook 4
 ```
 
 Reports are written to `oak/insights/` and can be committed to git for team visibility.

--- a/.github/skills/codebase-intelligence/references/finding-related-code.md
+++ b/.github/skills/codebase-intelligence/references/finding-related-code.md
@@ -29,39 +29,39 @@ Use this workflow when:
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 
 # More results for broader exploration
-oak ci search "error handling and logging" --type code -n 20
+oak-dev ci search "error handling and logging" --type code -n 20
 ```
 
 ### Discover component relationships
 
 ```bash
 # Find code related to two concepts (relationship)
-oak ci search "how does AuthService interact with TokenManager"
+oak-dev ci search "how does AuthService interact with TokenManager"
 
 # Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 
 # Get context about a specific relationship
-oak ci context "relationship between UserService and PaymentProcessor"
+oak-dev ci context "relationship between UserService and PaymentProcessor"
 ```
 
 ### Get context for current work
 
 ```bash
 # Find code related to files you're editing
-oak ci context "similar implementations" -f src/services/user.py
+oak-dev ci context "similar implementations" -f src/services/user.py
 
 # Find related code for a specific task
-oak ci context "validation patterns" -f src/api/handlers.py
+oak-dev ci context "validation patterns" -f src/api/handlers.py
 
 # Get context with specific files in focus
-oak ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
+oak-dev ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
 ```
 
 ## Example: Finding Similar Implementations
@@ -70,13 +70,13 @@ oak ci context "how auth middleware relates to session handling" -f src/middlewa
 
 ```bash
 # 1. Find existing endpoint implementations
-oak ci search "REST API endpoint handler" --type code
+oak-dev ci search "REST API endpoint handler" --type code
 
 # 2. Find validation patterns
-oak ci search "input validation for API requests" --type code
+oak-dev ci search "input validation for API requests" --type code
 
 # 3. Find error handling patterns
-oak ci search "API error response formatting" --type code
+oak-dev ci search "API error response formatting" --type code
 ```
 
 **What you'll find**: Consistent patterns used elsewhere, even if the endpoints are in different modules or use different naming conventions.
@@ -92,7 +92,7 @@ oak ci search "API error response formatting" --type code
 # - "token_refresh" (authentication adjacent)
 
 # Semantic search finds them all:
-oak ci search "user authentication and authorization" --type code -n 20
+oak-dev ci search "user authentication and authorization" --type code -n 20
 ```
 
 ## Example: Understanding Component Relationships
@@ -101,13 +101,13 @@ oak ci search "user authentication and authorization" --type code -n 20
 
 ```bash
 # 1. Search for code mentioning both concepts
-oak ci search "OrderService inventory management"
+oak-dev ci search "OrderService inventory management"
 
 # 2. Get broader context
-oak ci context "relationship between orders and inventory"
+oak-dev ci context "relationship between orders and inventory"
 
 # 3. Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 ```
 
 **What you'll find**: Semantic search reveals event handlers, shared models, and integration points that aren't obvious from imports alone.
@@ -120,7 +120,7 @@ oak ci search "order creation inventory update"
 - Increase `-n` limit when exploring broadly
 - Use `--type code` to focus on implementation (exclude memories)
 - Combine multiple searches to build complete picture
-- Combine with `oak ci context` for richer understanding
+- Combine with `oak-dev ci context` for richer understanding
 
 ## Output
 
@@ -131,8 +131,8 @@ Results include:
 
 ```bash
 # JSON output (default) - good for parsing
-oak ci search "database transactions" -f json
+oak-dev ci search "database transactions" -f json
 
 # Text output - good for reading
-oak ci search "database transactions" -f text
+oak-dev ci search "database transactions" -f text
 ```

--- a/.github/skills/codebase-intelligence/references/impact-analysis.md
+++ b/.github/skills/codebase-intelligence/references/impact-analysis.md
@@ -22,23 +22,23 @@ Semantic search finds code related by meaning. When you change how something wor
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 
 # Search for code using similar patterns
-oak ci search "code that depends on JWT token format" --type code
+oak-dev ci search "code that depends on JWT token format" --type code
 ```
 
 ### Check for related memories
 
 ```bash
 # Find past learnings that might be relevant
-oak ci search "gotchas with auth changes" --type memory
+oak-dev ci search "gotchas with auth changes" --type memory
 
 # Find decisions that might be affected
-oak ci search "decisions about token handling"
+oak-dev ci search "decisions about token handling"
 ```
 
 ## Example: Before Refactoring
@@ -47,16 +47,16 @@ oak ci search "decisions about token handling"
 
 ```bash
 # 1. Find all code conceptually related to payment processing
-oak ci search "payment processing flow" --type code -n 20
+oak-dev ci search "payment processing flow" --type code -n 20
 
 # 2. Find code that handles payment errors (often missed)
-oak ci search "payment error handling and recovery" --type code
+oak-dev ci search "payment error handling and recovery" --type code
 
 # 3. Find related integrations
-oak ci search "payment gateway integration" --type code
+oak-dev ci search "payment gateway integration" --type code
 
 # 4. Check for past issues/decisions
-oak ci search "payment processing gotchas" --type memory
+oak-dev ci search "payment processing gotchas" --type memory
 ```
 
 **What you'll find**:
@@ -74,25 +74,25 @@ Many of these won't show up in import analysis!
 
 ```bash
 # Find all code that might parse this response
-oak ci search "user API response handling" --type code
+oak-dev ci search "user API response handling" --type code
 
 # Find frontend code consuming this API
-oak ci search "fetch user data from API" --type code
+oak-dev ci search "fetch user data from API" --type code
 
 # Find tests that might break
-oak ci search "user API endpoint tests" --type code
+oak-dev ci search "user API endpoint tests" --type code
 
 # Check for integration patterns
-oak ci context "code that depends on user API format"
+oak-dev ci context "code that depends on user API format"
 ```
 
 ## Impact Analysis Workflow
 
 1. **Identify the change**: What are you modifying?
-2. **Search for direct usage**: `oak ci search "ComponentName" --type code`
-3. **Search for conceptual usage**: `oak ci search "what ComponentName does" --type code`
-4. **Check for patterns**: `oak ci search "code using similar patterns" --type code`
-5. **Review memories**: `oak ci search "past issues with this area" --type memory`
+2. **Search for direct usage**: `oak-dev ci search "ComponentName" --type code`
+3. **Search for conceptual usage**: `oak-dev ci search "what ComponentName does" --type code`
+4. **Check for patterns**: `oak-dev ci search "code using similar patterns" --type code`
+5. **Review memories**: `oak-dev ci search "past issues with this area" --type memory`
 6. **Read the results**: Assess which code might need updates
 
 ## Tips
@@ -101,4 +101,4 @@ oak ci context "code that depends on user API format"
 - Search for what the code *does*, not just its name
 - Include error handling and edge cases in your search
 - Check memories for past issues in this area
-- Use `oak ci context` with the file you're changing for focused results
+- Use `oak-dev ci context` with the file you're changing for focused results

--- a/.github/skills/codebase-intelligence/references/querying-databases.md
+++ b/.github/skills/codebase-intelligence/references/querying-databases.md
@@ -19,7 +19,7 @@ Use direct SQL when browsing the dashboard is insufficient and detailed analysis
 - Full-text keyword search (FTS5 `MATCH` — different from semantic vector search)
 - When the CI daemon is not running (SQLite is always readable directly)
 
-**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak ci remember`.
+**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak-dev ci remember`.
 
 ## Database Location
 
@@ -69,13 +69,13 @@ For everyday codebase intelligence (semantic search, storing memories, retrievin
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search (code, memories, plans) |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory or learning |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
-| — | `oak ci memories --type gotcha` | Browse memories by type |
-| — | `oak ci sessions` | List session summaries |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search (code, memories, plans) |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory or learning |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
+| — | `oak-dev ci memories --type gotcha` | Browse memories by type |
+| — | `oak-dev ci sessions` | List session summaries |
 
-Check daemon status with `oak ci status`. Start with `oak ci start` if needed.
+Check daemon status with `oak-dev ci status`. Start with `oak-dev ci start` if needed.
 
 ## Important Notes
 
@@ -99,10 +99,10 @@ For complete schema DDL and advanced query patterns, consult:
 For automated analysis that runs these queries and produces reports, use the analysis agent:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.github/skills/project-governance/SKILL.md
+++ b/.github/skills/project-governance/SKILL.md
@@ -26,16 +26,16 @@ Create, modify, and maintain project constitutions, agent instruction files, and
 ### Create an RFC
 
 ```bash
-oak rfc create --title "Add caching layer" --template feature
-oak rfc list
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc create --title "Add caching layer" --template feature
+oak-dev rfc list
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ### Sync agent instruction files
 
 ```bash
-oak rules sync-agents          # Sync constitution references to all agent files
-oak rules detect-existing      # Discover all configured agent instruction files
+oak-dev rules sync-agents          # Sync constitution references to all agent files
+oak-dev rules detect-existing      # Discover all configured agent instruction files
 ```
 
 ## Commands Reference
@@ -44,21 +44,21 @@ oak rules detect-existing      # Discover all configured agent instruction files
 
 | Command | Purpose |
 |---------|---------|
-| `oak rules sync-agents` | Sync constitution references to all agent instruction files |
-| `oak rules sync-agents --dry-run` | Preview what files will be checked/updated |
-| `oak rules detect-existing` | Discover all configured agent instruction files |
-| `oak rules detect-existing --json` | Machine-readable output of agent files |
+| `oak-dev rules sync-agents` | Sync constitution references to all agent instruction files |
+| `oak-dev rules sync-agents --dry-run` | Preview what files will be checked/updated |
+| `oak-dev rules detect-existing` | Discover all configured agent instruction files |
+| `oak-dev rules detect-existing --json` | Machine-readable output of agent files |
 
 ### RFC commands
 
 | Command | Purpose |
 |---------|---------|
-| `oak rfc create --title "..." --template <type>` | Create a new RFC |
-| `oak rfc list` | List all RFCs |
-| `oak rfc validate <path>` | Validate RFC structure and content |
-| `oak rfc show <path>` | Show RFC details |
-| `oak rfc adopt <path>` | Mark RFC as adopted |
-| `oak rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
+| `oak-dev rfc create --title "..." --template <type>` | Create a new RFC |
+| `oak-dev rfc list` | List all RFCs |
+| `oak-dev rfc validate <path>` | Validate RFC structure and content |
+| `oak-dev rfc show <path>` | Show RFC details |
+| `oak-dev rfc adopt <path>` | Mark RFC as adopted |
+| `oak-dev rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
 
 ## When to Use
 
@@ -98,16 +98,16 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 
 1. **Read** the current constitution (`oak/constitution.md`)
 2. **Add** the full rule to the appropriate section using RFC 2119 language (MUST, SHOULD, MAY)
-3. **Sync** to all agent files: `oak rules sync-agents`
+3. **Sync** to all agent files: `oak-dev rules sync-agents`
 
 **CRITICAL:** Rules MUST be added to the constitution FIRST, then synced to agent files. Never add a rule only to an agent file.
 
 ### RFC lifecycle
 
-1. **Create**: `oak rfc create --title "..." --template feature --author "Name"`
+1. **Create**: `oak-dev rfc create --title "..." --template feature --author "Name"`
 2. **Fill in**: Problem context, proposed solution, trade-offs, alternatives
 3. **Review**: Use the review checklist (see `references/reviewing-rfcs.md`)
-4. **Adopt or abandon**: `oak rfc adopt <path>` or `oak rfc abandon <path> --reason "..."`
+4. **Adopt or abandon**: `oak-dev rfc adopt <path>` or `oak-dev rfc abandon <path> --reason "..."`
 
 ### RFC review checklist (summary)
 
@@ -131,7 +131,7 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 ## Files
 
 - Constitution: `oak/constitution.md` or `.constitution.md`
-- Agent files: Run `oak rules detect-existing` to discover all agent instruction files
+- Agent files: Run `oak-dev rules detect-existing` to discover all agent instruction files
 - RFCs: `oak/rfc/RFC-XXX-short-title.md`
 
 ## Deep Dives

--- a/.github/skills/project-governance/references/agent-files-guide.md
+++ b/.github/skills/project-governance/references/agent-files-guide.md
@@ -15,7 +15,7 @@ Agent instruction files are **short, operational documents** that:
 ### Option 1: Use OAK's sync command
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ### Option 2: Create manually
@@ -65,8 +65,8 @@ Do NOT hardcode agent file names. Use OAK's built-in commands:
 
 ```bash
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 Agent files are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -77,10 +77,10 @@ When the constitution is updated, sync changes to all agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## What Makes a Good Agent File

--- a/.github/skills/project-governance/references/constitution-guide.md
+++ b/.github/skills/project-governance/references/constitution-guide.md
@@ -116,7 +116,7 @@ Create `oak/constitution.md` (or `.constitution.md` at root):
 After creating the constitution, create agent files that reference it:
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## Adding Rules to Existing Constitution
@@ -130,8 +130,8 @@ oak rules sync-agents
 cat oak/constitution.md  # or .constitution.md
 
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 **Do NOT hardcode agent file names.** Agents are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -168,13 +168,13 @@ After the constitution is updated, sync to all configured agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
-If manual updates are needed, use `oak rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
+If manual updates are needed, use `oak-dev rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
 
 ```markdown
 ## [Rule Name]
@@ -182,7 +182,7 @@ If manual updates are needed, use `oak rules detect-existing --json` to get the 
 **MUST NOT** [brief prohibition]. See §[section] of `oak/constitution.md` for the full rule, rationale, and verification command.
 ```
 
-**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak rules detect-existing`.
+**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak-dev rules detect-existing`.
 
 ## Example Workflow
 
@@ -196,4 +196,4 @@ User: "We need to establish coding standards for this Python project"
    - Quality gate (`make check` or equivalent)
    - Anchor files (point to best existing modules)
 3. **Create agent files** referencing the constitution
-4. **Sync**: `oak rules sync-agents`
+4. **Sync**: `oak-dev rules sync-agents`

--- a/.github/skills/project-governance/references/creating-rfcs.md
+++ b/.github/skills/project-governance/references/creating-rfcs.md
@@ -22,13 +22,13 @@ Use this workflow when:
 
 ```bash
 # Create an RFC interactively
-oak rfc create --title "Add caching layer" --template feature
+oak-dev rfc create --title "Add caching layer" --template feature
 
 # List existing RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate an RFC
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ## RFC Templates
@@ -70,7 +70,7 @@ What else did we consider? Why not those?
 ### 1. Create the RFC
 
 ```bash
-oak rfc create --title "Your RFC Title" --template feature --author "Your Name"
+oak-dev rfc create --title "Your RFC Title" --template feature --author "Your Name"
 ```
 
 This creates a file in `oak/rfc/` with the proper structure.
@@ -88,13 +88,13 @@ Edit the generated file to add:
 The RFC is now ready for team review. Once approved:
 
 ```bash
-oak rfc adopt oak/rfc/RFC-XXX-your-rfc.md
+oak-dev rfc adopt oak/rfc/RFC-XXX-your-rfc.md
 ```
 
 Or if abandoned:
 
 ```bash
-oak rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
+oak-dev rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
 ```
 
 ## Tips

--- a/.github/skills/project-governance/references/reviewing-rfcs.md
+++ b/.github/skills/project-governance/references/reviewing-rfcs.md
@@ -21,13 +21,13 @@ Use this workflow when:
 
 ```bash
 # List all RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate a specific RFC
-oak rfc validate oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc validate oak/rfc/RFC-001-your-rfc.md
 
 # Show RFC details
-oak rfc show oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc show oak/rfc/RFC-001-your-rfc.md
 ```
 
 ## Review Checklist
@@ -88,7 +88,7 @@ When providing feedback, structure it as:
 Run automated validation:
 
 ```bash
-oak rfc validate oak/rfc/RFC-XXX-title.md
+oak-dev rfc validate oak/rfc/RFC-XXX-title.md
 ```
 
 This checks:
@@ -111,5 +111,5 @@ This checks:
 RFCs are in `oak/rfc/` directory. List all with:
 
 ```bash
-oak rfc list
+oak-dev rfc list
 ```

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "oak-ci": {
       "type": "stdio",
-      "command": "oak",
+      "command": "oak-dev",
       "args": [
         "ci",
         "mcp"

--- a/.oak/config.yaml
+++ b/.oak/config.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0rc2.dev7+g94eed463f.d20260207
+version: 1.0.4.dev0+gdae04f6e3.d20260209
 agents:
 - copilot
 - opencode
@@ -136,3 +136,4 @@ codebase_intelligence:
   - '*.mo'
   backup:
     on_upgrade: true
+  cli_command: oak-dev

--- a/.opencode/plugins/oak-ci.ts
+++ b/.opencode/plugins/oak-ci.ts
@@ -19,7 +19,7 @@
 import type { Plugin } from "@opencode-ai/plugin";
 
 /**
- * Helper to call oak ci hook command with JSON payload
+ * Helper to call oak-dev ci hook command with JSON payload
  */
 async function callOakHook(
   $: any,
@@ -29,7 +29,7 @@ async function callOakHook(
   try {
     const jsonPayload = JSON.stringify(payload);
     const result =
-      await $`echo ${jsonPayload} | oak ci hook ${hookName} --agent opencode`;
+      await $`echo ${jsonPayload} | oak-dev ci hook ${hookName} --agent opencode`;
     return { success: true, result };
   } catch (error) {
     // Don't let hook failures break OpenCode - log and continue

--- a/.opencode/skills/codebase-intelligence/SKILL.md
+++ b/.opencode/skills/codebase-intelligence/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   in previous sessions, looking up past conversations or outcomes, querying
   session history, checking activity logs, browsing memories, running SQL
   against activities.db, or exploring patterns that grep would miss. Do NOT use
-  for storing memories — use oak_remember or oak ci remember instead.
+  for storing memories — use oak_remember or oak-dev ci remember instead.
 allowed-tools: Bash, Read
 user-invocable: true
 ---
@@ -23,20 +23,20 @@ Search, analyze, and query your codebase using semantic vector search, impact an
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 ```
 
 ### Impact analysis
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 ```
 
 ### Session and memory lookup
@@ -47,10 +47,10 @@ sqlite3 -readonly -header -column .oak/ci/activities.db \
   "SELECT id, agent, title, status, datetime(created_at_epoch, 'unixepoch', 'localtime') as started FROM sessions ORDER BY created_at_epoch DESC LIMIT 5;"
 
 # Search past decisions and learnings
-oak ci search "authentication refactor decision" --type memory
+oak-dev ci search "authentication refactor decision" --type memory
 
 # Browse memories by type
-oak ci memories --type decision
+oak-dev ci memories --type decision
 ```
 
 ### Database query
@@ -66,22 +66,22 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "SELECT count(*) FROM se
 
 | Command | Purpose |
 |---------|---------|
-| `oak ci search "query" --type code` | Semantic vector search for code |
-| `oak ci search "query" --type memory` | Semantic search for memories |
-| `oak ci search "query" -n 20` | Broader search with more results |
-| `oak ci context "task" -f <file>` | Get context for current work |
-| `oak ci remember "observation"` | Store a memory (NOT via SQL) |
-| `oak ci memories --type gotcha` | Browse memories by type |
-| `oak ci sessions` | List session summaries |
-| `oak ci status` | Check daemon status |
+| `oak-dev ci search "query" --type code` | Semantic vector search for code |
+| `oak-dev ci search "query" --type memory` | Semantic search for memories |
+| `oak-dev ci search "query" -n 20` | Broader search with more results |
+| `oak-dev ci context "task" -f <file>` | Get context for current work |
+| `oak-dev ci remember "observation"` | Store a memory (NOT via SQL) |
+| `oak-dev ci memories --type gotcha` | Browse memories by type |
+| `oak-dev ci sessions` | List session summaries |
+| `oak-dev ci status` | Check daemon status |
 
 ### MCP tools
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
 
 ### Direct SQL
 
@@ -93,15 +93,15 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 
 | Need | Tool | Example |
 |------|------|---------|
-| Find similar implementations | `oak ci search --type code` | "retry with exponential backoff" |
-| Understand component relationships | `oak ci context` | "how auth middleware relates to session handling" |
-| Assess refactoring risk | `oak ci search --type code -n 20` | "PaymentProcessor error handling" |
-| Find past decisions/gotchas | `oak ci search --type memory` | "gotchas with auth changes" |
+| Find similar implementations | `oak-dev ci search --type code` | "retry with exponential backoff" |
+| Understand component relationships | `oak-dev ci context` | "how auth middleware relates to session handling" |
+| Assess refactoring risk | `oak-dev ci search --type code -n 20` | "PaymentProcessor error handling" |
+| Find past decisions/gotchas | `oak-dev ci search --type memory` | "gotchas with auth changes" |
 | Recall previous discussions | `sqlite3 -readonly` | `SELECT title, summary FROM sessions WHERE ...` |
-| Find what was done before | `oak ci memories` / `sqlite3` | "what did we decide about caching?" |
+| Find what was done before | `oak-dev ci memories` / `sqlite3` | "what did we decide about caching?" |
 | Query session history | `sqlite3 -readonly` | `SELECT * FROM sessions ORDER BY ...` |
 | Aggregate usage stats | `sqlite3 -readonly` | `SELECT agent_name, sum(cost_usd) FROM agent_runs ...` |
-| Run automated analysis | `oak ci agent run` | `oak ci agent run usage-report` |
+| Run automated analysis | `oak-dev ci agent run` | `oak-dev ci agent run usage-report` |
 
 ## Why Semantic Search Over Grep
 
@@ -217,10 +217,10 @@ ORDER BY next_run_at_epoch;
 For automated analysis that runs queries and produces reports:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.opencode/skills/codebase-intelligence/references/analysis-playbooks.md
+++ b/.opencode/skills/codebase-intelligence/references/analysis-playbooks.md
@@ -2,7 +2,7 @@
 
 Structured multi-query workflows for analyzing CI data. Each playbook is a sequence of queries that build on each other to answer a specific question.
 
-These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak ci agent run <task-name>`).
+These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak-dev ci agent run <task-name>`).
 
 ## Playbook 1: Usage & Cost Analysis
 
@@ -223,10 +223,10 @@ LIMIT 10;
 These playbooks can be run automatically via the analysis agent:
 
 ```bash
-oak ci agent run usage-report          # Playbook 1
-oak ci agent run productivity-report   # Playbook 2
-oak ci agent run codebase-activity-report  # Playbook 3
-oak ci agent run prompt-analysis       # Playbook 4
+oak-dev ci agent run usage-report          # Playbook 1
+oak-dev ci agent run productivity-report   # Playbook 2
+oak-dev ci agent run codebase-activity-report  # Playbook 3
+oak-dev ci agent run prompt-analysis       # Playbook 4
 ```
 
 Reports are written to `oak/insights/` and can be committed to git for team visibility.

--- a/.opencode/skills/codebase-intelligence/references/finding-related-code.md
+++ b/.opencode/skills/codebase-intelligence/references/finding-related-code.md
@@ -29,39 +29,39 @@ Use this workflow when:
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 
 # More results for broader exploration
-oak ci search "error handling and logging" --type code -n 20
+oak-dev ci search "error handling and logging" --type code -n 20
 ```
 
 ### Discover component relationships
 
 ```bash
 # Find code related to two concepts (relationship)
-oak ci search "how does AuthService interact with TokenManager"
+oak-dev ci search "how does AuthService interact with TokenManager"
 
 # Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 
 # Get context about a specific relationship
-oak ci context "relationship between UserService and PaymentProcessor"
+oak-dev ci context "relationship between UserService and PaymentProcessor"
 ```
 
 ### Get context for current work
 
 ```bash
 # Find code related to files you're editing
-oak ci context "similar implementations" -f src/services/user.py
+oak-dev ci context "similar implementations" -f src/services/user.py
 
 # Find related code for a specific task
-oak ci context "validation patterns" -f src/api/handlers.py
+oak-dev ci context "validation patterns" -f src/api/handlers.py
 
 # Get context with specific files in focus
-oak ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
+oak-dev ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
 ```
 
 ## Example: Finding Similar Implementations
@@ -70,13 +70,13 @@ oak ci context "how auth middleware relates to session handling" -f src/middlewa
 
 ```bash
 # 1. Find existing endpoint implementations
-oak ci search "REST API endpoint handler" --type code
+oak-dev ci search "REST API endpoint handler" --type code
 
 # 2. Find validation patterns
-oak ci search "input validation for API requests" --type code
+oak-dev ci search "input validation for API requests" --type code
 
 # 3. Find error handling patterns
-oak ci search "API error response formatting" --type code
+oak-dev ci search "API error response formatting" --type code
 ```
 
 **What you'll find**: Consistent patterns used elsewhere, even if the endpoints are in different modules or use different naming conventions.
@@ -92,7 +92,7 @@ oak ci search "API error response formatting" --type code
 # - "token_refresh" (authentication adjacent)
 
 # Semantic search finds them all:
-oak ci search "user authentication and authorization" --type code -n 20
+oak-dev ci search "user authentication and authorization" --type code -n 20
 ```
 
 ## Example: Understanding Component Relationships
@@ -101,13 +101,13 @@ oak ci search "user authentication and authorization" --type code -n 20
 
 ```bash
 # 1. Search for code mentioning both concepts
-oak ci search "OrderService inventory management"
+oak-dev ci search "OrderService inventory management"
 
 # 2. Get broader context
-oak ci context "relationship between orders and inventory"
+oak-dev ci context "relationship between orders and inventory"
 
 # 3. Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 ```
 
 **What you'll find**: Semantic search reveals event handlers, shared models, and integration points that aren't obvious from imports alone.
@@ -120,7 +120,7 @@ oak ci search "order creation inventory update"
 - Increase `-n` limit when exploring broadly
 - Use `--type code` to focus on implementation (exclude memories)
 - Combine multiple searches to build complete picture
-- Combine with `oak ci context` for richer understanding
+- Combine with `oak-dev ci context` for richer understanding
 
 ## Output
 
@@ -131,8 +131,8 @@ Results include:
 
 ```bash
 # JSON output (default) - good for parsing
-oak ci search "database transactions" -f json
+oak-dev ci search "database transactions" -f json
 
 # Text output - good for reading
-oak ci search "database transactions" -f text
+oak-dev ci search "database transactions" -f text
 ```

--- a/.opencode/skills/codebase-intelligence/references/impact-analysis.md
+++ b/.opencode/skills/codebase-intelligence/references/impact-analysis.md
@@ -22,23 +22,23 @@ Semantic search finds code related by meaning. When you change how something wor
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 
 # Search for code using similar patterns
-oak ci search "code that depends on JWT token format" --type code
+oak-dev ci search "code that depends on JWT token format" --type code
 ```
 
 ### Check for related memories
 
 ```bash
 # Find past learnings that might be relevant
-oak ci search "gotchas with auth changes" --type memory
+oak-dev ci search "gotchas with auth changes" --type memory
 
 # Find decisions that might be affected
-oak ci search "decisions about token handling"
+oak-dev ci search "decisions about token handling"
 ```
 
 ## Example: Before Refactoring
@@ -47,16 +47,16 @@ oak ci search "decisions about token handling"
 
 ```bash
 # 1. Find all code conceptually related to payment processing
-oak ci search "payment processing flow" --type code -n 20
+oak-dev ci search "payment processing flow" --type code -n 20
 
 # 2. Find code that handles payment errors (often missed)
-oak ci search "payment error handling and recovery" --type code
+oak-dev ci search "payment error handling and recovery" --type code
 
 # 3. Find related integrations
-oak ci search "payment gateway integration" --type code
+oak-dev ci search "payment gateway integration" --type code
 
 # 4. Check for past issues/decisions
-oak ci search "payment processing gotchas" --type memory
+oak-dev ci search "payment processing gotchas" --type memory
 ```
 
 **What you'll find**:
@@ -74,25 +74,25 @@ Many of these won't show up in import analysis!
 
 ```bash
 # Find all code that might parse this response
-oak ci search "user API response handling" --type code
+oak-dev ci search "user API response handling" --type code
 
 # Find frontend code consuming this API
-oak ci search "fetch user data from API" --type code
+oak-dev ci search "fetch user data from API" --type code
 
 # Find tests that might break
-oak ci search "user API endpoint tests" --type code
+oak-dev ci search "user API endpoint tests" --type code
 
 # Check for integration patterns
-oak ci context "code that depends on user API format"
+oak-dev ci context "code that depends on user API format"
 ```
 
 ## Impact Analysis Workflow
 
 1. **Identify the change**: What are you modifying?
-2. **Search for direct usage**: `oak ci search "ComponentName" --type code`
-3. **Search for conceptual usage**: `oak ci search "what ComponentName does" --type code`
-4. **Check for patterns**: `oak ci search "code using similar patterns" --type code`
-5. **Review memories**: `oak ci search "past issues with this area" --type memory`
+2. **Search for direct usage**: `oak-dev ci search "ComponentName" --type code`
+3. **Search for conceptual usage**: `oak-dev ci search "what ComponentName does" --type code`
+4. **Check for patterns**: `oak-dev ci search "code using similar patterns" --type code`
+5. **Review memories**: `oak-dev ci search "past issues with this area" --type memory`
 6. **Read the results**: Assess which code might need updates
 
 ## Tips
@@ -101,4 +101,4 @@ oak ci context "code that depends on user API format"
 - Search for what the code *does*, not just its name
 - Include error handling and edge cases in your search
 - Check memories for past issues in this area
-- Use `oak ci context` with the file you're changing for focused results
+- Use `oak-dev ci context` with the file you're changing for focused results

--- a/.opencode/skills/codebase-intelligence/references/querying-databases.md
+++ b/.opencode/skills/codebase-intelligence/references/querying-databases.md
@@ -19,7 +19,7 @@ Use direct SQL when browsing the dashboard is insufficient and detailed analysis
 - Full-text keyword search (FTS5 `MATCH` — different from semantic vector search)
 - When the CI daemon is not running (SQLite is always readable directly)
 
-**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak ci remember`.
+**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak-dev ci remember`.
 
 ## Database Location
 
@@ -69,13 +69,13 @@ For everyday codebase intelligence (semantic search, storing memories, retrievin
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search (code, memories, plans) |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory or learning |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
-| — | `oak ci memories --type gotcha` | Browse memories by type |
-| — | `oak ci sessions` | List session summaries |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search (code, memories, plans) |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory or learning |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
+| — | `oak-dev ci memories --type gotcha` | Browse memories by type |
+| — | `oak-dev ci sessions` | List session summaries |
 
-Check daemon status with `oak ci status`. Start with `oak ci start` if needed.
+Check daemon status with `oak-dev ci status`. Start with `oak-dev ci start` if needed.
 
 ## Important Notes
 
@@ -99,10 +99,10 @@ For complete schema DDL and advanced query patterns, consult:
 For automated analysis that runs these queries and produces reports, use the analysis agent:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.opencode/skills/project-governance/SKILL.md
+++ b/.opencode/skills/project-governance/SKILL.md
@@ -26,16 +26,16 @@ Create, modify, and maintain project constitutions, agent instruction files, and
 ### Create an RFC
 
 ```bash
-oak rfc create --title "Add caching layer" --template feature
-oak rfc list
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc create --title "Add caching layer" --template feature
+oak-dev rfc list
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ### Sync agent instruction files
 
 ```bash
-oak rules sync-agents          # Sync constitution references to all agent files
-oak rules detect-existing      # Discover all configured agent instruction files
+oak-dev rules sync-agents          # Sync constitution references to all agent files
+oak-dev rules detect-existing      # Discover all configured agent instruction files
 ```
 
 ## Commands Reference
@@ -44,21 +44,21 @@ oak rules detect-existing      # Discover all configured agent instruction files
 
 | Command | Purpose |
 |---------|---------|
-| `oak rules sync-agents` | Sync constitution references to all agent instruction files |
-| `oak rules sync-agents --dry-run` | Preview what files will be checked/updated |
-| `oak rules detect-existing` | Discover all configured agent instruction files |
-| `oak rules detect-existing --json` | Machine-readable output of agent files |
+| `oak-dev rules sync-agents` | Sync constitution references to all agent instruction files |
+| `oak-dev rules sync-agents --dry-run` | Preview what files will be checked/updated |
+| `oak-dev rules detect-existing` | Discover all configured agent instruction files |
+| `oak-dev rules detect-existing --json` | Machine-readable output of agent files |
 
 ### RFC commands
 
 | Command | Purpose |
 |---------|---------|
-| `oak rfc create --title "..." --template <type>` | Create a new RFC |
-| `oak rfc list` | List all RFCs |
-| `oak rfc validate <path>` | Validate RFC structure and content |
-| `oak rfc show <path>` | Show RFC details |
-| `oak rfc adopt <path>` | Mark RFC as adopted |
-| `oak rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
+| `oak-dev rfc create --title "..." --template <type>` | Create a new RFC |
+| `oak-dev rfc list` | List all RFCs |
+| `oak-dev rfc validate <path>` | Validate RFC structure and content |
+| `oak-dev rfc show <path>` | Show RFC details |
+| `oak-dev rfc adopt <path>` | Mark RFC as adopted |
+| `oak-dev rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
 
 ## When to Use
 
@@ -98,16 +98,16 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 
 1. **Read** the current constitution (`oak/constitution.md`)
 2. **Add** the full rule to the appropriate section using RFC 2119 language (MUST, SHOULD, MAY)
-3. **Sync** to all agent files: `oak rules sync-agents`
+3. **Sync** to all agent files: `oak-dev rules sync-agents`
 
 **CRITICAL:** Rules MUST be added to the constitution FIRST, then synced to agent files. Never add a rule only to an agent file.
 
 ### RFC lifecycle
 
-1. **Create**: `oak rfc create --title "..." --template feature --author "Name"`
+1. **Create**: `oak-dev rfc create --title "..." --template feature --author "Name"`
 2. **Fill in**: Problem context, proposed solution, trade-offs, alternatives
 3. **Review**: Use the review checklist (see `references/reviewing-rfcs.md`)
-4. **Adopt or abandon**: `oak rfc adopt <path>` or `oak rfc abandon <path> --reason "..."`
+4. **Adopt or abandon**: `oak-dev rfc adopt <path>` or `oak-dev rfc abandon <path> --reason "..."`
 
 ### RFC review checklist (summary)
 
@@ -131,7 +131,7 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 ## Files
 
 - Constitution: `oak/constitution.md` or `.constitution.md`
-- Agent files: Run `oak rules detect-existing` to discover all agent instruction files
+- Agent files: Run `oak-dev rules detect-existing` to discover all agent instruction files
 - RFCs: `oak/rfc/RFC-XXX-short-title.md`
 
 ## Deep Dives

--- a/.opencode/skills/project-governance/references/agent-files-guide.md
+++ b/.opencode/skills/project-governance/references/agent-files-guide.md
@@ -15,7 +15,7 @@ Agent instruction files are **short, operational documents** that:
 ### Option 1: Use OAK's sync command
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ### Option 2: Create manually
@@ -65,8 +65,8 @@ Do NOT hardcode agent file names. Use OAK's built-in commands:
 
 ```bash
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 Agent files are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -77,10 +77,10 @@ When the constitution is updated, sync changes to all agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## What Makes a Good Agent File

--- a/.opencode/skills/project-governance/references/constitution-guide.md
+++ b/.opencode/skills/project-governance/references/constitution-guide.md
@@ -116,7 +116,7 @@ Create `oak/constitution.md` (or `.constitution.md` at root):
 After creating the constitution, create agent files that reference it:
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## Adding Rules to Existing Constitution
@@ -130,8 +130,8 @@ oak rules sync-agents
 cat oak/constitution.md  # or .constitution.md
 
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 **Do NOT hardcode agent file names.** Agents are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -168,13 +168,13 @@ After the constitution is updated, sync to all configured agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
-If manual updates are needed, use `oak rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
+If manual updates are needed, use `oak-dev rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
 
 ```markdown
 ## [Rule Name]
@@ -182,7 +182,7 @@ If manual updates are needed, use `oak rules detect-existing --json` to get the 
 **MUST NOT** [brief prohibition]. See §[section] of `oak/constitution.md` for the full rule, rationale, and verification command.
 ```
 
-**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak rules detect-existing`.
+**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak-dev rules detect-existing`.
 
 ## Example Workflow
 
@@ -196,4 +196,4 @@ User: "We need to establish coding standards for this Python project"
    - Quality gate (`make check` or equivalent)
    - Anchor files (point to best existing modules)
 3. **Create agent files** referencing the constitution
-4. **Sync**: `oak rules sync-agents`
+4. **Sync**: `oak-dev rules sync-agents`

--- a/.opencode/skills/project-governance/references/creating-rfcs.md
+++ b/.opencode/skills/project-governance/references/creating-rfcs.md
@@ -22,13 +22,13 @@ Use this workflow when:
 
 ```bash
 # Create an RFC interactively
-oak rfc create --title "Add caching layer" --template feature
+oak-dev rfc create --title "Add caching layer" --template feature
 
 # List existing RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate an RFC
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ## RFC Templates
@@ -70,7 +70,7 @@ What else did we consider? Why not those?
 ### 1. Create the RFC
 
 ```bash
-oak rfc create --title "Your RFC Title" --template feature --author "Your Name"
+oak-dev rfc create --title "Your RFC Title" --template feature --author "Your Name"
 ```
 
 This creates a file in `oak/rfc/` with the proper structure.
@@ -88,13 +88,13 @@ Edit the generated file to add:
 The RFC is now ready for team review. Once approved:
 
 ```bash
-oak rfc adopt oak/rfc/RFC-XXX-your-rfc.md
+oak-dev rfc adopt oak/rfc/RFC-XXX-your-rfc.md
 ```
 
 Or if abandoned:
 
 ```bash
-oak rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
+oak-dev rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
 ```
 
 ## Tips

--- a/.opencode/skills/project-governance/references/reviewing-rfcs.md
+++ b/.opencode/skills/project-governance/references/reviewing-rfcs.md
@@ -21,13 +21,13 @@ Use this workflow when:
 
 ```bash
 # List all RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate a specific RFC
-oak rfc validate oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc validate oak/rfc/RFC-001-your-rfc.md
 
 # Show RFC details
-oak rfc show oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc show oak/rfc/RFC-001-your-rfc.md
 ```
 
 ## Review Checklist
@@ -88,7 +88,7 @@ When providing feedback, structure it as:
 Run automated validation:
 
 ```bash
-oak rfc validate oak/rfc/RFC-XXX-title.md
+oak-dev rfc validate oak/rfc/RFC-XXX-title.md
 ```
 
 This checks:
@@ -111,5 +111,5 @@ This checks:
 RFCs are in `oak/rfc/` directory. List all with:
 
 ```bash
-oak rfc list
+oak-dev rfc list
 ```

--- a/.windsurf/hooks.json
+++ b/.windsurf/hooks.json
@@ -2,32 +2,32 @@
   "hooks": {
     "pre_user_prompt": [
       {
-        "command": "oak ci hook pre_user_prompt --agent windsurf"
+        "command": "oak-dev ci hook pre_user_prompt --agent windsurf"
       }
     ],
     "post_cascade_response": [
       {
-        "command": "oak ci hook post_cascade_response --agent windsurf"
+        "command": "oak-dev ci hook post_cascade_response --agent windsurf"
       }
     ],
     "post_write_code": [
       {
-        "command": "oak ci hook post_write_code --agent windsurf"
+        "command": "oak-dev ci hook post_write_code --agent windsurf"
       }
     ],
     "post_read_code": [
       {
-        "command": "oak ci hook post_read_code --agent windsurf"
+        "command": "oak-dev ci hook post_read_code --agent windsurf"
       }
     ],
     "post_run_command": [
       {
-        "command": "oak ci hook post_run_command --agent windsurf"
+        "command": "oak-dev ci hook post_run_command --agent windsurf"
       }
     ],
     "post_mcp_tool_use": [
       {
-        "command": "oak ci hook post_mcp_tool_use --agent windsurf"
+        "command": "oak-dev ci hook post_mcp_tool_use --agent windsurf"
       }
     ]
   },

--- a/.windsurf/settings.json
+++ b/.windsurf/settings.json
@@ -1,5 +1,6 @@
 {
   "windsurf.cascadeCommandsAllowList": [
-    "oak"
+    "oak",
+    "oak-dev"
   ]
 }

--- a/.windsurf/skills/codebase-intelligence/SKILL.md
+++ b/.windsurf/skills/codebase-intelligence/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   in previous sessions, looking up past conversations or outcomes, querying
   session history, checking activity logs, browsing memories, running SQL
   against activities.db, or exploring patterns that grep would miss. Do NOT use
-  for storing memories — use oak_remember or oak ci remember instead.
+  for storing memories — use oak_remember or oak-dev ci remember instead.
 allowed-tools: Bash, Read
 user-invocable: true
 ---
@@ -23,20 +23,20 @@ Search, analyze, and query your codebase using semantic vector search, impact an
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 ```
 
 ### Impact analysis
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 ```
 
 ### Session and memory lookup
@@ -47,10 +47,10 @@ sqlite3 -readonly -header -column .oak/ci/activities.db \
   "SELECT id, agent, title, status, datetime(created_at_epoch, 'unixepoch', 'localtime') as started FROM sessions ORDER BY created_at_epoch DESC LIMIT 5;"
 
 # Search past decisions and learnings
-oak ci search "authentication refactor decision" --type memory
+oak-dev ci search "authentication refactor decision" --type memory
 
 # Browse memories by type
-oak ci memories --type decision
+oak-dev ci memories --type decision
 ```
 
 ### Database query
@@ -66,22 +66,22 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "SELECT count(*) FROM se
 
 | Command | Purpose |
 |---------|---------|
-| `oak ci search "query" --type code` | Semantic vector search for code |
-| `oak ci search "query" --type memory` | Semantic search for memories |
-| `oak ci search "query" -n 20` | Broader search with more results |
-| `oak ci context "task" -f <file>` | Get context for current work |
-| `oak ci remember "observation"` | Store a memory (NOT via SQL) |
-| `oak ci memories --type gotcha` | Browse memories by type |
-| `oak ci sessions` | List session summaries |
-| `oak ci status` | Check daemon status |
+| `oak-dev ci search "query" --type code` | Semantic vector search for code |
+| `oak-dev ci search "query" --type memory` | Semantic search for memories |
+| `oak-dev ci search "query" -n 20` | Broader search with more results |
+| `oak-dev ci context "task" -f <file>` | Get context for current work |
+| `oak-dev ci remember "observation"` | Store a memory (NOT via SQL) |
+| `oak-dev ci memories --type gotcha` | Browse memories by type |
+| `oak-dev ci sessions` | List session summaries |
+| `oak-dev ci status` | Check daemon status |
 
 ### MCP tools
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
 
 ### Direct SQL
 
@@ -93,15 +93,15 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 
 | Need | Tool | Example |
 |------|------|---------|
-| Find similar implementations | `oak ci search --type code` | "retry with exponential backoff" |
-| Understand component relationships | `oak ci context` | "how auth middleware relates to session handling" |
-| Assess refactoring risk | `oak ci search --type code -n 20` | "PaymentProcessor error handling" |
-| Find past decisions/gotchas | `oak ci search --type memory` | "gotchas with auth changes" |
+| Find similar implementations | `oak-dev ci search --type code` | "retry with exponential backoff" |
+| Understand component relationships | `oak-dev ci context` | "how auth middleware relates to session handling" |
+| Assess refactoring risk | `oak-dev ci search --type code -n 20` | "PaymentProcessor error handling" |
+| Find past decisions/gotchas | `oak-dev ci search --type memory` | "gotchas with auth changes" |
 | Recall previous discussions | `sqlite3 -readonly` | `SELECT title, summary FROM sessions WHERE ...` |
-| Find what was done before | `oak ci memories` / `sqlite3` | "what did we decide about caching?" |
+| Find what was done before | `oak-dev ci memories` / `sqlite3` | "what did we decide about caching?" |
 | Query session history | `sqlite3 -readonly` | `SELECT * FROM sessions ORDER BY ...` |
 | Aggregate usage stats | `sqlite3 -readonly` | `SELECT agent_name, sum(cost_usd) FROM agent_runs ...` |
-| Run automated analysis | `oak ci agent run` | `oak ci agent run usage-report` |
+| Run automated analysis | `oak-dev ci agent run` | `oak-dev ci agent run usage-report` |
 
 ## Why Semantic Search Over Grep
 
@@ -217,10 +217,10 @@ ORDER BY next_run_at_epoch;
 For automated analysis that runs queries and produces reports:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.windsurf/skills/codebase-intelligence/references/analysis-playbooks.md
+++ b/.windsurf/skills/codebase-intelligence/references/analysis-playbooks.md
@@ -2,7 +2,7 @@
 
 Structured multi-query workflows for analyzing CI data. Each playbook is a sequence of queries that build on each other to answer a specific question.
 
-These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak ci agent run <task-name>`).
+These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak-dev ci agent run <task-name>`).
 
 ## Playbook 1: Usage & Cost Analysis
 
@@ -223,10 +223,10 @@ LIMIT 10;
 These playbooks can be run automatically via the analysis agent:
 
 ```bash
-oak ci agent run usage-report          # Playbook 1
-oak ci agent run productivity-report   # Playbook 2
-oak ci agent run codebase-activity-report  # Playbook 3
-oak ci agent run prompt-analysis       # Playbook 4
+oak-dev ci agent run usage-report          # Playbook 1
+oak-dev ci agent run productivity-report   # Playbook 2
+oak-dev ci agent run codebase-activity-report  # Playbook 3
+oak-dev ci agent run prompt-analysis       # Playbook 4
 ```
 
 Reports are written to `oak/insights/` and can be committed to git for team visibility.

--- a/.windsurf/skills/codebase-intelligence/references/finding-related-code.md
+++ b/.windsurf/skills/codebase-intelligence/references/finding-related-code.md
@@ -29,39 +29,39 @@ Use this workflow when:
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+oak-dev ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+oak-dev ci search "retry with exponential backoff" --type code
 
 # More results for broader exploration
-oak ci search "error handling and logging" --type code -n 20
+oak-dev ci search "error handling and logging" --type code -n 20
 ```
 
 ### Discover component relationships
 
 ```bash
 # Find code related to two concepts (relationship)
-oak ci search "how does AuthService interact with TokenManager"
+oak-dev ci search "how does AuthService interact with TokenManager"
 
 # Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 
 # Get context about a specific relationship
-oak ci context "relationship between UserService and PaymentProcessor"
+oak-dev ci context "relationship between UserService and PaymentProcessor"
 ```
 
 ### Get context for current work
 
 ```bash
 # Find code related to files you're editing
-oak ci context "similar implementations" -f src/services/user.py
+oak-dev ci context "similar implementations" -f src/services/user.py
 
 # Find related code for a specific task
-oak ci context "validation patterns" -f src/api/handlers.py
+oak-dev ci context "validation patterns" -f src/api/handlers.py
 
 # Get context with specific files in focus
-oak ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
+oak-dev ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
 ```
 
 ## Example: Finding Similar Implementations
@@ -70,13 +70,13 @@ oak ci context "how auth middleware relates to session handling" -f src/middlewa
 
 ```bash
 # 1. Find existing endpoint implementations
-oak ci search "REST API endpoint handler" --type code
+oak-dev ci search "REST API endpoint handler" --type code
 
 # 2. Find validation patterns
-oak ci search "input validation for API requests" --type code
+oak-dev ci search "input validation for API requests" --type code
 
 # 3. Find error handling patterns
-oak ci search "API error response formatting" --type code
+oak-dev ci search "API error response formatting" --type code
 ```
 
 **What you'll find**: Consistent patterns used elsewhere, even if the endpoints are in different modules or use different naming conventions.
@@ -92,7 +92,7 @@ oak ci search "API error response formatting" --type code
 # - "token_refresh" (authentication adjacent)
 
 # Semantic search finds them all:
-oak ci search "user authentication and authorization" --type code -n 20
+oak-dev ci search "user authentication and authorization" --type code -n 20
 ```
 
 ## Example: Understanding Component Relationships
@@ -101,13 +101,13 @@ oak ci search "user authentication and authorization" --type code -n 20
 
 ```bash
 # 1. Search for code mentioning both concepts
-oak ci search "OrderService inventory management"
+oak-dev ci search "OrderService inventory management"
 
 # 2. Get broader context
-oak ci context "relationship between orders and inventory"
+oak-dev ci context "relationship between orders and inventory"
 
 # 3. Search for data flow patterns
-oak ci search "order creation inventory update"
+oak-dev ci search "order creation inventory update"
 ```
 
 **What you'll find**: Semantic search reveals event handlers, shared models, and integration points that aren't obvious from imports alone.
@@ -120,7 +120,7 @@ oak ci search "order creation inventory update"
 - Increase `-n` limit when exploring broadly
 - Use `--type code` to focus on implementation (exclude memories)
 - Combine multiple searches to build complete picture
-- Combine with `oak ci context` for richer understanding
+- Combine with `oak-dev ci context` for richer understanding
 
 ## Output
 
@@ -131,8 +131,8 @@ Results include:
 
 ```bash
 # JSON output (default) - good for parsing
-oak ci search "database transactions" -f json
+oak-dev ci search "database transactions" -f json
 
 # Text output - good for reading
-oak ci search "database transactions" -f text
+oak-dev ci search "database transactions" -f text
 ```

--- a/.windsurf/skills/codebase-intelligence/references/impact-analysis.md
+++ b/.windsurf/skills/codebase-intelligence/references/impact-analysis.md
@@ -22,23 +22,23 @@ Semantic search finds code related by meaning. When you change how something wor
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+oak-dev ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+oak-dev ci context "impact of changes" -f src/services/auth.py
 
 # Search for code using similar patterns
-oak ci search "code that depends on JWT token format" --type code
+oak-dev ci search "code that depends on JWT token format" --type code
 ```
 
 ### Check for related memories
 
 ```bash
 # Find past learnings that might be relevant
-oak ci search "gotchas with auth changes" --type memory
+oak-dev ci search "gotchas with auth changes" --type memory
 
 # Find decisions that might be affected
-oak ci search "decisions about token handling"
+oak-dev ci search "decisions about token handling"
 ```
 
 ## Example: Before Refactoring
@@ -47,16 +47,16 @@ oak ci search "decisions about token handling"
 
 ```bash
 # 1. Find all code conceptually related to payment processing
-oak ci search "payment processing flow" --type code -n 20
+oak-dev ci search "payment processing flow" --type code -n 20
 
 # 2. Find code that handles payment errors (often missed)
-oak ci search "payment error handling and recovery" --type code
+oak-dev ci search "payment error handling and recovery" --type code
 
 # 3. Find related integrations
-oak ci search "payment gateway integration" --type code
+oak-dev ci search "payment gateway integration" --type code
 
 # 4. Check for past issues/decisions
-oak ci search "payment processing gotchas" --type memory
+oak-dev ci search "payment processing gotchas" --type memory
 ```
 
 **What you'll find**:
@@ -74,25 +74,25 @@ Many of these won't show up in import analysis!
 
 ```bash
 # Find all code that might parse this response
-oak ci search "user API response handling" --type code
+oak-dev ci search "user API response handling" --type code
 
 # Find frontend code consuming this API
-oak ci search "fetch user data from API" --type code
+oak-dev ci search "fetch user data from API" --type code
 
 # Find tests that might break
-oak ci search "user API endpoint tests" --type code
+oak-dev ci search "user API endpoint tests" --type code
 
 # Check for integration patterns
-oak ci context "code that depends on user API format"
+oak-dev ci context "code that depends on user API format"
 ```
 
 ## Impact Analysis Workflow
 
 1. **Identify the change**: What are you modifying?
-2. **Search for direct usage**: `oak ci search "ComponentName" --type code`
-3. **Search for conceptual usage**: `oak ci search "what ComponentName does" --type code`
-4. **Check for patterns**: `oak ci search "code using similar patterns" --type code`
-5. **Review memories**: `oak ci search "past issues with this area" --type memory`
+2. **Search for direct usage**: `oak-dev ci search "ComponentName" --type code`
+3. **Search for conceptual usage**: `oak-dev ci search "what ComponentName does" --type code`
+4. **Check for patterns**: `oak-dev ci search "code using similar patterns" --type code`
+5. **Review memories**: `oak-dev ci search "past issues with this area" --type memory`
 6. **Read the results**: Assess which code might need updates
 
 ## Tips
@@ -101,4 +101,4 @@ oak ci context "code that depends on user API format"
 - Search for what the code *does*, not just its name
 - Include error handling and edge cases in your search
 - Check memories for past issues in this area
-- Use `oak ci context` with the file you're changing for focused results
+- Use `oak-dev ci context` with the file you're changing for focused results

--- a/.windsurf/skills/codebase-intelligence/references/querying-databases.md
+++ b/.windsurf/skills/codebase-intelligence/references/querying-databases.md
@@ -19,7 +19,7 @@ Use direct SQL when browsing the dashboard is insufficient and detailed analysis
 - Full-text keyword search (FTS5 `MATCH` — different from semantic vector search)
 - When the CI daemon is not running (SQLite is always readable directly)
 
-**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak ci remember`.
+**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak-dev ci remember`.
 
 ## Database Location
 
@@ -69,13 +69,13 @@ For everyday codebase intelligence (semantic search, storing memories, retrievin
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search (code, memories, plans) |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory or learning |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
-| — | `oak ci memories --type gotcha` | Browse memories by type |
-| — | `oak ci sessions` | List session summaries |
+| `oak_search` | `oak-dev ci search "query"` | Semantic vector search (code, memories, plans) |
+| `oak_remember` | `oak-dev ci remember "observation"` | Store a memory or learning |
+| `oak_context` | `oak-dev ci context "task"` | Get task-relevant context |
+| — | `oak-dev ci memories --type gotcha` | Browse memories by type |
+| — | `oak-dev ci sessions` | List session summaries |
 
-Check daemon status with `oak ci status`. Start with `oak ci start` if needed.
+Check daemon status with `oak-dev ci status`. Start with `oak-dev ci start` if needed.
 
 ## Important Notes
 
@@ -99,10 +99,10 @@ For complete schema DDL and advanced query patterns, consult:
 For automated analysis that runs these queries and produces reports, use the analysis agent:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+oak-dev ci agent run usage-report              # Cost and token usage trends
+oak-dev ci agent run productivity-report       # Session quality and error rates
+oak-dev ci agent run codebase-activity-report  # File hotspots and tool patterns
+oak-dev ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/.windsurf/skills/project-governance/SKILL.md
+++ b/.windsurf/skills/project-governance/SKILL.md
@@ -26,16 +26,16 @@ Create, modify, and maintain project constitutions, agent instruction files, and
 ### Create an RFC
 
 ```bash
-oak rfc create --title "Add caching layer" --template feature
-oak rfc list
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc create --title "Add caching layer" --template feature
+oak-dev rfc list
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ### Sync agent instruction files
 
 ```bash
-oak rules sync-agents          # Sync constitution references to all agent files
-oak rules detect-existing      # Discover all configured agent instruction files
+oak-dev rules sync-agents          # Sync constitution references to all agent files
+oak-dev rules detect-existing      # Discover all configured agent instruction files
 ```
 
 ## Commands Reference
@@ -44,21 +44,21 @@ oak rules detect-existing      # Discover all configured agent instruction files
 
 | Command | Purpose |
 |---------|---------|
-| `oak rules sync-agents` | Sync constitution references to all agent instruction files |
-| `oak rules sync-agents --dry-run` | Preview what files will be checked/updated |
-| `oak rules detect-existing` | Discover all configured agent instruction files |
-| `oak rules detect-existing --json` | Machine-readable output of agent files |
+| `oak-dev rules sync-agents` | Sync constitution references to all agent instruction files |
+| `oak-dev rules sync-agents --dry-run` | Preview what files will be checked/updated |
+| `oak-dev rules detect-existing` | Discover all configured agent instruction files |
+| `oak-dev rules detect-existing --json` | Machine-readable output of agent files |
 
 ### RFC commands
 
 | Command | Purpose |
 |---------|---------|
-| `oak rfc create --title "..." --template <type>` | Create a new RFC |
-| `oak rfc list` | List all RFCs |
-| `oak rfc validate <path>` | Validate RFC structure and content |
-| `oak rfc show <path>` | Show RFC details |
-| `oak rfc adopt <path>` | Mark RFC as adopted |
-| `oak rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
+| `oak-dev rfc create --title "..." --template <type>` | Create a new RFC |
+| `oak-dev rfc list` | List all RFCs |
+| `oak-dev rfc validate <path>` | Validate RFC structure and content |
+| `oak-dev rfc show <path>` | Show RFC details |
+| `oak-dev rfc adopt <path>` | Mark RFC as adopted |
+| `oak-dev rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
 
 ## When to Use
 
@@ -98,16 +98,16 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 
 1. **Read** the current constitution (`oak/constitution.md`)
 2. **Add** the full rule to the appropriate section using RFC 2119 language (MUST, SHOULD, MAY)
-3. **Sync** to all agent files: `oak rules sync-agents`
+3. **Sync** to all agent files: `oak-dev rules sync-agents`
 
 **CRITICAL:** Rules MUST be added to the constitution FIRST, then synced to agent files. Never add a rule only to an agent file.
 
 ### RFC lifecycle
 
-1. **Create**: `oak rfc create --title "..." --template feature --author "Name"`
+1. **Create**: `oak-dev rfc create --title "..." --template feature --author "Name"`
 2. **Fill in**: Problem context, proposed solution, trade-offs, alternatives
 3. **Review**: Use the review checklist (see `references/reviewing-rfcs.md`)
-4. **Adopt or abandon**: `oak rfc adopt <path>` or `oak rfc abandon <path> --reason "..."`
+4. **Adopt or abandon**: `oak-dev rfc adopt <path>` or `oak-dev rfc abandon <path> --reason "..."`
 
 ### RFC review checklist (summary)
 
@@ -131,7 +131,7 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 ## Files
 
 - Constitution: `oak/constitution.md` or `.constitution.md`
-- Agent files: Run `oak rules detect-existing` to discover all agent instruction files
+- Agent files: Run `oak-dev rules detect-existing` to discover all agent instruction files
 - RFCs: `oak/rfc/RFC-XXX-short-title.md`
 
 ## Deep Dives

--- a/.windsurf/skills/project-governance/references/agent-files-guide.md
+++ b/.windsurf/skills/project-governance/references/agent-files-guide.md
@@ -15,7 +15,7 @@ Agent instruction files are **short, operational documents** that:
 ### Option 1: Use OAK's sync command
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ### Option 2: Create manually
@@ -65,8 +65,8 @@ Do NOT hardcode agent file names. Use OAK's built-in commands:
 
 ```bash
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 Agent files are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -77,10 +77,10 @@ When the constitution is updated, sync changes to all agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## What Makes a Good Agent File

--- a/.windsurf/skills/project-governance/references/constitution-guide.md
+++ b/.windsurf/skills/project-governance/references/constitution-guide.md
@@ -116,7 +116,7 @@ Create `oak/constitution.md` (or `.constitution.md` at root):
 After creating the constitution, create agent files that reference it:
 
 ```bash
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
 ## Adding Rules to Existing Constitution
@@ -130,8 +130,8 @@ oak rules sync-agents
 cat oak/constitution.md  # or .constitution.md
 
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+oak-dev rules detect-existing
+oak-dev rules detect-existing --json  # machine-readable output
 ```
 
 **Do NOT hardcode agent file names.** Agents are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -168,13 +168,13 @@ After the constitution is updated, sync to all configured agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+oak-dev rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+oak-dev rules sync-agents
 ```
 
-If manual updates are needed, use `oak rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
+If manual updates are needed, use `oak-dev rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
 
 ```markdown
 ## [Rule Name]
@@ -182,7 +182,7 @@ If manual updates are needed, use `oak rules detect-existing --json` to get the 
 **MUST NOT** [brief prohibition]. See §[section] of `oak/constitution.md` for the full rule, rationale, and verification command.
 ```
 
-**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak rules detect-existing`.
+**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak-dev rules detect-existing`.
 
 ## Example Workflow
 
@@ -196,4 +196,4 @@ User: "We need to establish coding standards for this Python project"
    - Quality gate (`make check` or equivalent)
    - Anchor files (point to best existing modules)
 3. **Create agent files** referencing the constitution
-4. **Sync**: `oak rules sync-agents`
+4. **Sync**: `oak-dev rules sync-agents`

--- a/.windsurf/skills/project-governance/references/creating-rfcs.md
+++ b/.windsurf/skills/project-governance/references/creating-rfcs.md
@@ -22,13 +22,13 @@ Use this workflow when:
 
 ```bash
 # Create an RFC interactively
-oak rfc create --title "Add caching layer" --template feature
+oak-dev rfc create --title "Add caching layer" --template feature
 
 # List existing RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate an RFC
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+oak-dev rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ## RFC Templates
@@ -70,7 +70,7 @@ What else did we consider? Why not those?
 ### 1. Create the RFC
 
 ```bash
-oak rfc create --title "Your RFC Title" --template feature --author "Your Name"
+oak-dev rfc create --title "Your RFC Title" --template feature --author "Your Name"
 ```
 
 This creates a file in `oak/rfc/` with the proper structure.
@@ -88,13 +88,13 @@ Edit the generated file to add:
 The RFC is now ready for team review. Once approved:
 
 ```bash
-oak rfc adopt oak/rfc/RFC-XXX-your-rfc.md
+oak-dev rfc adopt oak/rfc/RFC-XXX-your-rfc.md
 ```
 
 Or if abandoned:
 
 ```bash
-oak rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
+oak-dev rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
 ```
 
 ## Tips

--- a/.windsurf/skills/project-governance/references/reviewing-rfcs.md
+++ b/.windsurf/skills/project-governance/references/reviewing-rfcs.md
@@ -21,13 +21,13 @@ Use this workflow when:
 
 ```bash
 # List all RFCs
-oak rfc list
+oak-dev rfc list
 
 # Validate a specific RFC
-oak rfc validate oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc validate oak/rfc/RFC-001-your-rfc.md
 
 # Show RFC details
-oak rfc show oak/rfc/RFC-001-your-rfc.md
+oak-dev rfc show oak/rfc/RFC-001-your-rfc.md
 ```
 
 ## Review Checklist
@@ -88,7 +88,7 @@ When providing feedback, structure it as:
 Run automated validation:
 
 ```bash
-oak rfc validate oak/rfc/RFC-XXX-title.md
+oak-dev rfc validate oak/rfc/RFC-XXX-title.md
 ```
 
 This checks:
@@ -111,5 +111,5 @@ This checks:
 RFCs are in `oak/rfc/` directory. List all with:
 
 ```bash
-oak rfc list
+oak-dev rfc list
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-02-09
+
+### Added
+
+- Published `oak-ci` package to PyPI (v1.0.2) with cross-platform install script supporting macOS, Linux, and Windows PATH detection — [Publish oak-ci 1.0.2 and fix install script](http://localhost:38388/activity/sessions/44aa9400-db40-4db8-971e-5991cf0434b4)
+- Concise feature request issue template for GitHub — [Add concise feature request template to repo](http://localhost:38388/activity/sessions/e6d294c4-3847-4b80-ad8c-4489287492b8)
+- CI workflow with idempotent install scripts, mypy gating, and custom domain for GitHub Pages documentation — [Configure CI workflow and idempotent install scripts](http://localhost:38388/activity/sessions/019c3f47-583c-79b0-8b7b-9b794c797b5f)
+
+### Changed
+
+- Agent-kit templates refactored for consistent placeholders (`{{ agent_name }}`, `{{ skill_name }}`) with automatic injection during upgrades — [Refactor Oak agent‑kit templates for consistent placeholders and upgrade auto...](http://localhost:38388/activity/sessions/019c4361-2300-7c91-9a72-e41fe2c9fefa)
+- Repository history cleaned and squashed for public open-source release — [Refactor repository history for clean public release](http://localhost:38388/activity/sessions/3d44092e-6cb0-433f-a611-d1a06ec6fcb7)
+- `.oak/state.yaml` excluded from version control and leftover installer migrations removed for clean first-run experience — [Configure .oak/state.yaml exclusion and remove leftover migrations](http://localhost:38388/activity/sessions/1ec7b4a2-ef29-48db-873b-930c52c5cac2)
+- Agent indexer configured to ignore build artifact directories — [Configure agent to ignore build artifact directories](http://localhost:38388/activity/sessions/16b837e8-90d1-4f38-b4f5-2c2c0d0721eb)
+
+### Fixed
+
+- Fix GitHub Pages broken links, `baseurl` configuration, and hard-coded documentation URLs across README, QUICKSTART, and issue templates — [Fix GitHub Pages links, update baseurl, and correct documentation URLs](http://localhost:38388/activity/sessions/248550ba-3db2-4a40-a4f5-fcf4c0235974)
+- Fix install script failing to add agent binary to PATH on macOS due to incorrect shell detection logic — [Publish oak-ci 1.0.2 and fix install script](http://localhost:38388/activity/sessions/44aa9400-db40-4db8-971e-5991cf0434b4)
+
+### Improved
+
+- Daemon UI TaskList CPU usage reduced from ~10% to ~2% idle via `React.memo`, `useCallback`, debounced search, and batched API requests — [Refactor TaskList to Reduce CPU Usage in Oak Daemon UI](http://localhost:38388/activity/sessions/cdd818d1-75e4-48ee-9d48-2f59af2dfe53)
+- Test suite audited: stale imports removed, test-to-source mapping updated, orphan tests flagged — [Debug test suite audit and stale import cleanup](http://localhost:38388/activity/sessions/c89831a0-e4af-4f79-b8fb-99e6ccea904b)
+
+### Notes
+
+> **Gotcha**: `.oak/state.yaml` tracks applied migration names. If migrations are removed from the codebase but their names remain in state.yaml, the migration runner may attempt to reference non-existent modules, causing `ImportError` or silent failures during startup. After a clean release, ensure state.yaml is reset or excluded from version control.
+
+> **Gotcha**: The install script must handle both user-local and system installations. On macOS, `~/.local/bin` may not be on PATH by default — the installer now appends it to the appropriate shell profile (`.zshrc`, `.bash_profile`), but users with custom shell setups should verify manually.
+
+> **Gotcha**: GitHub issue templates must be placed in `.github/ISSUE_TEMPLATE/` with the `.yml` extension. A missing or misnamed file will silently not appear in the issue creation UI.
+
+## [Previous] - pre-1.0.2
+
 ### Added
 
 - Token-based authentication for daemon API and UI with file-backed secrets — [Implement token‑based authentication for API and UI](http://localhost:38388/activity/sessions/b172c7fd-12d6-463b-a540-9b676a173992)

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -51,7 +51,8 @@ Available RFC templates (specified via `--template` on `oak rfc create`):
 
 ## Agent Auto-Approval Settings
 
-During initialization, OAK installs agent-specific settings that enable auto-approval for `oak` commands:
+During initialization, OAK installs agent-specific settings that enable auto-approval
+for the configured OAK CLI command (`oak` by default):
 
 | Agent | Settings File |
 |-------|---------------|
@@ -62,6 +63,15 @@ During initialization, OAK installs agent-specific settings that enable auto-app
 | Windsurf | `.windsurf/settings.json` |
 
 Run `oak upgrade` to update agent settings to the latest version.
+
+If you need a different command in one repository (for example `oak-dev`), set:
+
+```bash
+oak ci config --cli-command oak-dev
+```
+
+This updates managed integrations in that project to use the new command.
+See [Codebase Intelligence Configuration](/open-agent-kit/features/codebase-intelligence/configuration/#cli-command-for-managed-integrations) for details.
 
 ## Agent Instruction Files
 

--- a/docs/src/content/docs/features/codebase-intelligence/configuration.md
+++ b/docs/src/content/docs/features/codebase-intelligence/configuration.md
@@ -161,6 +161,30 @@ Configure log rotation to manage disk usage:
 
 See the [Logs](/open-agent-kit/features/codebase-intelligence/logs/) page for details on viewing and filtering logs.
 
+## CLI Command For Managed Integrations
+
+CI-managed hooks, MCP registrations, and notify handlers use a configurable executable command.
+By default this is `oak`.
+
+This is a project-level command alias for managed integrations.
+Use it when you want one repository to run OAK through a different executable
+while other repositories keep using the default `oak`.
+
+```bash
+# Show current setting
+oak ci config --show
+
+# Use oak-dev for CI-managed integrations in this project
+oak ci config --cli-command oak-dev
+```
+
+Common use cases:
+- Avoid command-name conflicts with another local tool named `oak`
+- Keep a dev executable (`oak-dev`) in one repository while using stable `oak` everywhere else
+- Standardize wrappers (for example, team-specific launcher commands) on a single project
+
+After this change, OAK refreshes managed integrations so future hook/MCP/notify executions use the configured command.
+
 ## Directory Exclusions
 
 Control which directories are skipped during codebase indexing.

--- a/oak/agents/root-docs.yaml
+++ b/oak/agents/root-docs.yaml
@@ -52,7 +52,9 @@ default_task: |
   **Must contain:**
   - Tagline / one-sentence description
   - Problem statement (why this exists)
-  - Quick install (3–5 lines max, just the happy path)
+  - Quick install (3–5 lines max) — use the install script (`curl | sh`) as the
+    primary method since it's the most universal. Link to QUICKSTART.md for
+    Windows, pipx, uv, pip, and other alternatives.
   - One compelling usage example
   - Links to QUICKSTART.md, CONTRIBUTING.md, SECURITY.md
 
@@ -72,7 +74,7 @@ default_task: |
 
   **Must contain:**
   - Prerequisites (OS, runtime versions, dependencies)
-  - Multiple install methods if applicable (pip, make, source)
+  - Install script as the primary/recommended method, then alternatives (pipx, uv, pip)
   - Step-by-step first-run walkthrough
   - Configuration basics (environment variables, config files)
   - Troubleshooting section (THIS is the CI value-add — populate from gotcha memories)

--- a/opencode.json
+++ b/opencode.json
@@ -2,14 +2,15 @@
   "$schema": "https://opencode.ai/config.json",
   "permission": {
     "bash": {
-      "oak *": "allow"
+      "oak *": "allow",
+      "oak-dev *": "allow"
     }
   },
   "mcp": {
     "oak-ci": {
       "type": "local",
       "command": [
-        "oak",
+        "oak-dev",
         "ci",
         "mcp"
       ]

--- a/src/open_agent_kit/cli.py
+++ b/src/open_agent_kit/cli.py
@@ -15,7 +15,7 @@ from open_agent_kit.commands.rfc_cmd import rfc_app
 from open_agent_kit.commands.rules_cmd import rules_app
 from open_agent_kit.commands.skill_cmd import skill_app
 from open_agent_kit.commands.upgrade_cmd import upgrade_command
-from open_agent_kit.config.messages import HELP_TEXT
+from open_agent_kit.config.messages import HELP_TEXT, PROJECT_TAGLINE, PROJECT_URL
 from open_agent_kit.constants import VERSION
 from open_agent_kit.utils import print_banner, print_error, print_panel
 
@@ -25,7 +25,7 @@ load_dotenv(Path.cwd() / ".env", verbose=False)
 # Create main Typer app
 app = typer.Typer(
     name="oak",
-    help="AI-assisted engineering productivity tools",
+    help=PROJECT_TAGLINE,
     no_args_is_help=True,
     add_completion=False,
     rich_markup_mode="rich",
@@ -139,8 +139,8 @@ def version() -> None:
     """Show version information."""
     print_panel(
         f"[bold cyan]open-agent-kit[/bold cyan] version [green]{VERSION}[/green]\n\n"
-        "AI-assisted engineering productivity tools\n\n"
-        "[dim]https://github.com/sirkirby/open-agent-kit[/dim]",
+        f"{PROJECT_TAGLINE}\n\n"
+        f"[dim]{PROJECT_URL}[/dim]",
         title="Version",
         style="cyan",
     )
@@ -164,7 +164,7 @@ def main(
         is_eager=True,
     ),
 ) -> None:
-    """open-agent-kit - AI-assisted engineering productivity tools.
+    """open-agent-kit - AI-powered development workflows.
 
     A CLI tool for managing RFCs, project workflows, and team conventions
     with AI assistance from Claude, Copilot, Codex, or Cursor.
@@ -174,7 +174,7 @@ def main(
         oak rfc create "..."  # Create an RFC
         oak rfc list          # List all RFCs
 
-    For more information, visit: https://github.com/sirkirby/open-agent-kit
+    For more information, visit: https://oak.goondocks.co
     """
     # Handle version flag
     if version_flag:

--- a/src/open_agent_kit/config/messages.py
+++ b/src/open_agent_kit/config/messages.py
@@ -8,6 +8,13 @@ This module consolidates all user-facing messages including:
 """
 
 # =============================================================================
+# Project Metadata
+# =============================================================================
+
+PROJECT_TAGLINE = "Your Team's Memory in the Age of AI-Written Code"
+PROJECT_URL = "https://oak.goondocks.co"
+
+# =============================================================================
 # Banner and Help
 # =============================================================================
 
@@ -26,8 +33,8 @@ BANNER = """
 ╰─────────────────────────────────────────────────────────╯
 """
 
-HELP_TEXT = """
-[bold cyan]oak[/bold cyan] - Open Agent Kit: AI-powered development workflows
+HELP_TEXT = f"""
+[bold cyan]oak[/bold cyan] - Open Agent Kit: {PROJECT_TAGLINE}
 
 [bold]Primary Commands:[/bold]
   [cyan]init[/cyan]        Initialize .oak directory with templates and configs
@@ -53,7 +60,7 @@ HELP_TEXT = """
   2. Run [cyan]oak rfc create[/cyan] to create your first RFC
   3. See the Quick Start guide: [dim]QUICKSTART.md[/dim]
 
-For more information, visit: https://github.com/sirkirby/open-agent-kit
+For more information, visit: {PROJECT_URL}
 """
 
 NEXT_STEPS_INIT = """[bold green]What's Next?[/bold green]
@@ -282,9 +289,3 @@ PROGRESS_CHARS = {
     "current": "●",
     "error": "✗",
 }
-
-# =============================================================================
-# URLs
-# =============================================================================
-
-PROJECT_URL = "https://github.com/sirkirby/open-agent-kit"

--- a/src/open_agent_kit/features/codebase_intelligence/cli_command.py
+++ b/src/open_agent_kit/features/codebase_intelligence/cli_command.py
@@ -1,0 +1,58 @@
+"""Utilities for resolving and rewriting CI CLI command invocations."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from open_agent_kit.features.codebase_intelligence.constants import (
+    CI_CLI_COMMAND_DEFAULT,
+    CI_CLI_COMMAND_OAK_PREFIX,
+)
+
+logger = logging.getLogger(__name__)
+
+CLI_COMMAND_PLACEHOLDER = "{oak-cli-command}"
+
+
+def normalize_cli_command(command: str | None) -> str:
+    """Normalize configured CLI command, falling back to default."""
+    if command is None:
+        return CI_CLI_COMMAND_DEFAULT
+
+    normalized = command.strip()
+    if not normalized:
+        return CI_CLI_COMMAND_DEFAULT
+    return normalized
+
+
+def rewrite_oak_command(command: str, cli_command: str) -> str:
+    """Rewrite an ``oak ...`` command to use the configured CLI command."""
+    resolved = normalize_cli_command(cli_command)
+
+    if command == CI_CLI_COMMAND_DEFAULT:
+        return resolved
+
+    if command.startswith(CI_CLI_COMMAND_OAK_PREFIX):
+        suffix = command[len(CI_CLI_COMMAND_OAK_PREFIX) :]
+        return f"{resolved} {suffix}"
+
+    return command
+
+
+def resolve_ci_cli_command(project_root: Path) -> str:
+    """Resolve effective CLI command for CI-managed integrations in a project."""
+    try:
+        from open_agent_kit.features.codebase_intelligence.config import load_ci_config
+
+        config = load_ci_config(project_root)
+        return normalize_cli_command(config.cli_command)
+    except Exception as e:
+        logger.debug(f"Falling back to default CLI command: {e}")
+        return CI_CLI_COMMAND_DEFAULT
+
+
+def render_cli_command_placeholder(content: str, cli_command: str) -> str:
+    """Render CLI command placeholder tokens in content."""
+    resolved = normalize_cli_command(cli_command)
+    return content.replace(CLI_COMMAND_PLACEHOLDER, resolved)

--- a/src/open_agent_kit/features/codebase_intelligence/constants.py
+++ b/src/open_agent_kit/features/codebase_intelligence/constants.py
@@ -496,6 +496,12 @@ AGENT_NOTIFY_COMMAND_ARGS_CODEX: Final[tuple[str, ...]] = (
 )
 AGENT_NOTIFY_ENDPOINT: Final[str] = "/api/oak/ci/notify"
 
+# CI executable command configuration
+CI_CONFIG_KEY_CLI_COMMAND: Final[str] = "cli_command"
+CI_CLI_COMMAND_DEFAULT: Final[str] = AGENT_NOTIFY_COMMAND_OAK
+CI_CLI_COMMAND_VALIDATION_PATTERN: Final[str] = r"^[A-Za-z0-9._/\-\\]+$"
+CI_CLI_COMMAND_OAK_PREFIX: Final[str] = f"{AGENT_NOTIFY_COMMAND_OAK} "
+
 # OTel attribute keys for data extraction (from Codex PR #2103)
 OTEL_ATTR_CONVERSATION_ID: Final[str] = "conversation.id"
 OTEL_ATTR_APP_VERSION: Final[str] = "app.version"

--- a/src/open_agent_kit/features/codebase_intelligence/hooks/claude/hooks.json
+++ b/src/open_agent_kit/features/codebase_intelligence/hooks/claude/hooks.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/hooks.json",
-  "$comment": "Codebase Intelligence hooks for Claude Code. Uses `oak ci hook` command for cross-platform compatibility. OAK hooks are identified by the oak ci hook command pattern.",
+  "$comment": "Codebase Intelligence hooks for Claude Code. Uses `{oak-cli-command} ci hook` command for cross-platform compatibility. OAK hooks are identified by the {oak-cli-command} ci hook command pattern.",
   "hooks": {
     "SessionStart": [
       {
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook SessionStart --agent claude",
+            "command": "{oak-cli-command} ci hook SessionStart --agent claude",
             "timeout": 60
           }
         ]
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook UserPromptSubmit --agent claude",
+            "command": "{oak-cli-command} ci hook UserPromptSubmit --agent claude",
             "timeout": 60
           }
         ]
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook PostToolUse --agent claude",
+            "command": "{oak-cli-command} ci hook PostToolUse --agent claude",
             "timeout": 60
           }
         ]
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook Stop --agent claude",
+            "command": "{oak-cli-command} ci hook Stop --agent claude",
             "timeout": 60
           }
         ]
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook SessionEnd --agent claude",
+            "command": "{oak-cli-command} ci hook SessionEnd --agent claude",
             "timeout": 60
           }
         ]
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook PostToolUseFailure --agent claude",
+            "command": "{oak-cli-command} ci hook PostToolUseFailure --agent claude",
             "timeout": 60
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook SubagentStart --agent claude",
+            "command": "{oak-cli-command} ci hook SubagentStart --agent claude",
             "timeout": 60
           }
         ]
@@ -92,7 +92,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oak ci hook SubagentStop --agent claude",
+            "command": "{oak-cli-command} ci hook SubagentStop --agent claude",
             "timeout": 60
           }
         ]

--- a/src/open_agent_kit/features/codebase_intelligence/hooks/copilot/hooks.json
+++ b/src/open_agent_kit/features/codebase_intelligence/hooks/copilot/hooks.json
@@ -1,44 +1,44 @@
 {
-  "$comment": "Codebase Intelligence hooks for GitHub Copilot. Uses `oak ci hook` command for cross-platform compatibility. OAK hooks are identified by the oak ci hook command pattern. Copilot hooks are installed to .github/hooks/ per GitHub docs.",
+  "$comment": "Codebase Intelligence hooks for GitHub Copilot. Uses `{oak-cli-command} ci hook` command for cross-platform compatibility. OAK hooks are identified by the {oak-cli-command} ci hook command pattern. Copilot hooks are installed to .github/hooks/ per GitHub docs.",
   "version": 1,
   "hooks": {
     "sessionStart": [
       {
         "type": "command",
-        "bash": "oak ci hook sessionStart --agent copilot",
-        "powershell": "oak ci hook sessionStart --agent copilot",
+        "bash": "{oak-cli-command} ci hook sessionStart --agent copilot",
+        "powershell": "{oak-cli-command} ci hook sessionStart --agent copilot",
         "timeoutSec": 60
       }
     ],
     "sessionEnd": [
       {
         "type": "command",
-        "bash": "oak ci hook sessionEnd --agent copilot",
-        "powershell": "oak ci hook sessionEnd --agent copilot",
+        "bash": "{oak-cli-command} ci hook sessionEnd --agent copilot",
+        "powershell": "{oak-cli-command} ci hook sessionEnd --agent copilot",
         "timeoutSec": 60
       }
     ],
     "userPromptSubmitted": [
       {
         "type": "command",
-        "bash": "oak ci hook userPromptSubmitted --agent copilot",
-        "powershell": "oak ci hook userPromptSubmitted --agent copilot",
+        "bash": "{oak-cli-command} ci hook userPromptSubmitted --agent copilot",
+        "powershell": "{oak-cli-command} ci hook userPromptSubmitted --agent copilot",
         "timeoutSec": 60
       }
     ],
     "postToolUse": [
       {
         "type": "command",
-        "bash": "oak ci hook postToolUse --agent copilot",
-        "powershell": "oak ci hook postToolUse --agent copilot",
+        "bash": "{oak-cli-command} ci hook postToolUse --agent copilot",
+        "powershell": "{oak-cli-command} ci hook postToolUse --agent copilot",
         "timeoutSec": 60
       }
     ],
     "errorOccurred": [
       {
         "type": "command",
-        "bash": "oak ci hook errorOccurred --agent copilot",
-        "powershell": "oak ci hook errorOccurred --agent copilot",
+        "bash": "{oak-cli-command} ci hook errorOccurred --agent copilot",
+        "powershell": "{oak-cli-command} ci hook errorOccurred --agent copilot",
         "timeoutSec": 60,
         "comment": "Maps to post-tool-use-failure endpoint"
       }

--- a/src/open_agent_kit/features/codebase_intelligence/hooks/cursor/hooks.json
+++ b/src/open_agent_kit/features/codebase_intelligence/hooks/cursor/hooks.json
@@ -1,65 +1,65 @@
 {
-  "$comment": "Codebase Intelligence hooks for Cursor. Uses `oak ci hook` command for cross-platform compatibility. OAK hooks are identified by the oak ci hook command pattern.",
+  "$comment": "Codebase Intelligence hooks for Cursor. Uses `{oak-cli-command} ci hook` command for cross-platform compatibility. OAK hooks are identified by the {oak-cli-command} ci hook command pattern.",
   "version": 1,
   "hooks": {
     "sessionStart": [
       {
-        "command": "oak ci hook sessionStart --agent cursor"
+        "command": "{oak-cli-command} ci hook sessionStart --agent cursor"
       }
     ],
     "beforeSubmitPrompt": [
       {
-        "command": "oak ci hook beforeSubmitPrompt --agent cursor"
+        "command": "{oak-cli-command} ci hook beforeSubmitPrompt --agent cursor"
       }
     ],
     "afterFileEdit": [
       {
-        "command": "oak ci hook afterFileEdit --agent cursor"
+        "command": "{oak-cli-command} ci hook afterFileEdit --agent cursor"
       }
     ],
     "afterAgentResponse": [
       {
-        "command": "oak ci hook afterAgentResponse --agent cursor"
+        "command": "{oak-cli-command} ci hook afterAgentResponse --agent cursor"
       }
     ],
     "afterAgentThought": [
       {
-        "command": "oak ci hook afterAgentThought --agent cursor"
+        "command": "{oak-cli-command} ci hook afterAgentThought --agent cursor"
       }
     ],
     "postToolUse": [
       {
-        "command": "oak ci hook postToolUse --agent cursor"
+        "command": "{oak-cli-command} ci hook postToolUse --agent cursor"
       }
     ],
     "preCompact": [
       {
-        "command": "oak ci hook preCompact --agent cursor"
+        "command": "{oak-cli-command} ci hook preCompact --agent cursor"
       }
     ],
     "stop": [
       {
-        "command": "oak ci hook stop --agent cursor"
+        "command": "{oak-cli-command} ci hook stop --agent cursor"
       }
     ],
     "sessionEnd": [
       {
-        "command": "oak ci hook sessionEnd --agent cursor"
+        "command": "{oak-cli-command} ci hook sessionEnd --agent cursor"
       }
     ],
     "postToolUseFailure": [
       {
-        "command": "oak ci hook postToolUseFailure --agent cursor"
+        "command": "{oak-cli-command} ci hook postToolUseFailure --agent cursor"
       }
     ],
     "subagentStart": [
       {
-        "command": "oak ci hook subagentStart --agent cursor"
+        "command": "{oak-cli-command} ci hook subagentStart --agent cursor"
       }
     ],
     "subagentStop": [
       {
-        "command": "oak ci hook subagentStop --agent cursor"
+        "command": "{oak-cli-command} ci hook subagentStop --agent cursor"
       }
     ]
   }

--- a/src/open_agent_kit/features/codebase_intelligence/hooks/gemini/hooks.json
+++ b/src/open_agent_kit/features/codebase_intelligence/hooks/gemini/hooks.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Codebase Intelligence hooks for Gemini CLI. Uses `oak ci hook` command for cross-platform compatibility. OAK hooks are identified by the oak ci hook command pattern.",
+  "$comment": "Codebase Intelligence hooks for Gemini CLI. Uses `{oak-cli-command} ci hook` command for cross-platform compatibility. OAK hooks are identified by the {oak-cli-command} ci hook command pattern.",
   "hooks": {
     "SessionStart": [
       {
@@ -8,7 +8,7 @@
           {
             "name": "oak-ci-context",
             "type": "command",
-            "command": "oak ci hook SessionStart --agent gemini",
+            "command": "{oak-cli-command} ci hook SessionStart --agent gemini",
             "timeout": 60000
           }
         ]
@@ -21,7 +21,7 @@
           {
             "name": "oak-ci-prompt",
             "type": "command",
-            "command": "oak ci hook BeforeAgent --agent gemini",
+            "command": "{oak-cli-command} ci hook BeforeAgent --agent gemini",
             "timeout": 15000
           }
         ]
@@ -34,7 +34,7 @@
           {
             "name": "oak-ci-observe",
             "type": "command",
-            "command": "oak ci hook PostToolUse --agent gemini",
+            "command": "{oak-cli-command} ci hook PostToolUse --agent gemini",
             "timeout": 15000
           }
         ]
@@ -47,7 +47,7 @@
           {
             "name": "oak-ci-stop",
             "type": "command",
-            "command": "oak ci hook AfterAgent --agent gemini",
+            "command": "{oak-cli-command} ci hook AfterAgent --agent gemini",
             "timeout": 15000
           }
         ]
@@ -60,7 +60,7 @@
           {
             "name": "oak-ci-pre-compact",
             "type": "command",
-            "command": "oak ci hook PreCompress --agent gemini",
+            "command": "{oak-cli-command} ci hook PreCompress --agent gemini",
             "timeout": 15000
           }
         ]
@@ -73,7 +73,7 @@
           {
             "name": "oak-ci-session-end",
             "type": "command",
-            "command": "oak ci hook SessionEnd --agent gemini",
+            "command": "{oak-cli-command} ci hook SessionEnd --agent gemini",
             "timeout": 15000
           }
         ]

--- a/src/open_agent_kit/features/codebase_intelligence/hooks/opencode/oak-ci.ts
+++ b/src/open_agent_kit/features/codebase_intelligence/hooks/opencode/oak-ci.ts
@@ -19,7 +19,7 @@
 import type { Plugin } from "@opencode-ai/plugin";
 
 /**
- * Helper to call oak ci hook command with JSON payload
+ * Helper to call {oak-cli-command} ci hook command with JSON payload
  */
 async function callOakHook(
   $: any,
@@ -29,7 +29,7 @@ async function callOakHook(
   try {
     const jsonPayload = JSON.stringify(payload);
     const result =
-      await $`echo ${jsonPayload} | oak ci hook ${hookName} --agent opencode`;
+      await $`echo ${jsonPayload} | {oak-cli-command} ci hook ${hookName} --agent opencode`;
     return { success: true, result };
   } catch (error) {
     // Don't let hook failures break OpenCode - log and continue

--- a/src/open_agent_kit/features/codebase_intelligence/hooks/windsurf/hooks.json
+++ b/src/open_agent_kit/features/codebase_intelligence/hooks/windsurf/hooks.json
@@ -2,32 +2,32 @@
   "hooks": {
     "pre_user_prompt": [
       {
-        "command": "oak ci hook pre_user_prompt --agent windsurf"
+        "command": "{oak-cli-command} ci hook pre_user_prompt --agent windsurf"
       }
     ],
     "post_cascade_response": [
       {
-        "command": "oak ci hook post_cascade_response --agent windsurf"
+        "command": "{oak-cli-command} ci hook post_cascade_response --agent windsurf"
       }
     ],
     "post_write_code": [
       {
-        "command": "oak ci hook post_write_code --agent windsurf"
+        "command": "{oak-cli-command} ci hook post_write_code --agent windsurf"
       }
     ],
     "post_read_code": [
       {
-        "command": "oak ci hook post_read_code --agent windsurf"
+        "command": "{oak-cli-command} ci hook post_read_code --agent windsurf"
       }
     ],
     "post_run_command": [
       {
-        "command": "oak ci hook post_run_command --agent windsurf"
+        "command": "{oak-cli-command} ci hook post_run_command --agent windsurf"
       }
     ],
     "post_mcp_tool_use": [
       {
-        "command": "oak ci hook post_mcp_tool_use --agent windsurf"
+        "command": "{oak-cli-command} ci hook post_mcp_tool_use --agent windsurf"
       }
     ]
   }

--- a/src/open_agent_kit/features/codebase_intelligence/mcp/mcp.yaml
+++ b/src/open_agent_kit/features/codebase_intelligence/mcp/mcp.yaml
@@ -13,8 +13,8 @@ description: "OAK Codebase Intelligence - semantic code search and persistent me
 
 # The command to run the MCP server
 # The MCP server uses the current working directory to find the project.
-# Uses 'oak' directly, expecting it to be on PATH (installed via pipx, uv tool install, etc.)
-command: "oak ci mcp"
+# Uses a CLI command placeholder rendered from CI config (cli_command).
+command: "{oak-cli-command} ci mcp"
 
 # Server capabilities (for documentation/validation)
 capabilities:

--- a/src/open_agent_kit/features/codebase_intelligence/notifications/codex/notify_config.toml.j2
+++ b/src/open_agent_kit/features/codebase_intelligence/notifications/codex/notify_config.toml.j2
@@ -1,3 +1,3 @@
 # OAK Codebase Intelligence notify configuration for Codex
 
-notify = ["{{ notify_command }}"{% for arg in notify_args %}, "{{ arg }}"{% endfor %}{% if notify_script_path %}, "{{ notify_script_path }}"{% endif %}]
+notify = ["{oak-cli-command}"{% for arg in notify_args %}, "{{ arg }}"{% endfor %}{% if notify_script_path %}, "{{ notify_script_path }}"{% endif %}]

--- a/src/open_agent_kit/features/codebase_intelligence/service.py
+++ b/src/open_agent_kit/features/codebase_intelligence/service.py
@@ -10,6 +10,9 @@ from pathlib import Path
 from typing import Any, cast
 
 from open_agent_kit.config.paths import OAK_DIR
+from open_agent_kit.features.codebase_intelligence.cli_command import (
+    resolve_ci_cli_command,
+)
 from open_agent_kit.features.codebase_intelligence.constants import CI_DATA_DIR
 from open_agent_kit.features.codebase_intelligence.daemon.manager import get_project_port
 
@@ -17,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 # Path to the feature's MCP configuration directory
 MCP_TEMPLATE_DIR = Path(__file__).parent / "mcp"
+MCP_CLI_COMMAND_PLACEHOLDER = "{oak-cli-command}"
 
 
 class CodebaseIntelligenceService:
@@ -625,7 +629,11 @@ class CodebaseIntelligenceService:
 
         server_name = mcp_config.get("name", "oak-ci")
         # Build command (no longer uses --project flag, relies on cwd)
-        command = mcp_config.get("command", "oak ci mcp")
+        command = mcp_config.get("command", f"{MCP_CLI_COMMAND_PLACEHOLDER} ci mcp")
+        command = command.replace(
+            MCP_CLI_COMMAND_PLACEHOLDER,
+            resolve_ci_cli_command(self.project_root),
+        )
         # Remove any {{PROJECT_ROOT}} placeholder if present (legacy configs)
         command = command.replace("--project {{PROJECT_ROOT}}", "").strip()
         command = command.replace("{{PROJECT_ROOT}}", "").strip()

--- a/src/open_agent_kit/features/codebase_intelligence/skills/codebase-intelligence/SKILL.md
+++ b/src/open_agent_kit/features/codebase_intelligence/skills/codebase-intelligence/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   in previous sessions, looking up past conversations or outcomes, querying
   session history, checking activity logs, browsing memories, running SQL
   against activities.db, or exploring patterns that grep would miss. Do NOT use
-  for storing memories — use oak_remember or oak ci remember instead.
+  for storing memories — use oak_remember or {oak-cli-command} ci remember instead.
 allowed-tools: Bash, Read
 user-invocable: true
 ---
@@ -23,20 +23,20 @@ Search, analyze, and query your codebase using semantic vector search, impact an
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+{oak-cli-command} ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+{oak-cli-command} ci search "retry with exponential backoff" --type code
 ```
 
 ### Impact analysis
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+{oak-cli-command} ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+{oak-cli-command} ci context "impact of changes" -f src/services/auth.py
 ```
 
 ### Session and memory lookup
@@ -47,10 +47,10 @@ sqlite3 -readonly -header -column .oak/ci/activities.db \
   "SELECT id, agent, title, status, datetime(created_at_epoch, 'unixepoch', 'localtime') as started FROM sessions ORDER BY created_at_epoch DESC LIMIT 5;"
 
 # Search past decisions and learnings
-oak ci search "authentication refactor decision" --type memory
+{oak-cli-command} ci search "authentication refactor decision" --type memory
 
 # Browse memories by type
-oak ci memories --type decision
+{oak-cli-command} ci memories --type decision
 ```
 
 ### Database query
@@ -66,22 +66,22 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "SELECT count(*) FROM se
 
 | Command | Purpose |
 |---------|---------|
-| `oak ci search "query" --type code` | Semantic vector search for code |
-| `oak ci search "query" --type memory` | Semantic search for memories |
-| `oak ci search "query" -n 20` | Broader search with more results |
-| `oak ci context "task" -f <file>` | Get context for current work |
-| `oak ci remember "observation"` | Store a memory (NOT via SQL) |
-| `oak ci memories --type gotcha` | Browse memories by type |
-| `oak ci sessions` | List session summaries |
-| `oak ci status` | Check daemon status |
+| `{oak-cli-command} ci search "query" --type code` | Semantic vector search for code |
+| `{oak-cli-command} ci search "query" --type memory` | Semantic search for memories |
+| `{oak-cli-command} ci search "query" -n 20` | Broader search with more results |
+| `{oak-cli-command} ci context "task" -f <file>` | Get context for current work |
+| `{oak-cli-command} ci remember "observation"` | Store a memory (NOT via SQL) |
+| `{oak-cli-command} ci memories --type gotcha` | Browse memories by type |
+| `{oak-cli-command} ci sessions` | List session summaries |
+| `{oak-cli-command} ci status` | Check daemon status |
 
 ### MCP tools
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
+| `oak_search` | `{oak-cli-command} ci search "query"` | Semantic vector search |
+| `oak_remember` | `{oak-cli-command} ci remember "observation"` | Store a memory |
+| `oak_context` | `{oak-cli-command} ci context "task"` | Get task-relevant context |
 
 ### Direct SQL
 
@@ -93,15 +93,15 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 
 | Need | Tool | Example |
 |------|------|---------|
-| Find similar implementations | `oak ci search --type code` | "retry with exponential backoff" |
-| Understand component relationships | `oak ci context` | "how auth middleware relates to session handling" |
-| Assess refactoring risk | `oak ci search --type code -n 20` | "PaymentProcessor error handling" |
-| Find past decisions/gotchas | `oak ci search --type memory` | "gotchas with auth changes" |
+| Find similar implementations | `{oak-cli-command} ci search --type code` | "retry with exponential backoff" |
+| Understand component relationships | `{oak-cli-command} ci context` | "how auth middleware relates to session handling" |
+| Assess refactoring risk | `{oak-cli-command} ci search --type code -n 20` | "PaymentProcessor error handling" |
+| Find past decisions/gotchas | `{oak-cli-command} ci search --type memory` | "gotchas with auth changes" |
 | Recall previous discussions | `sqlite3 -readonly` | `SELECT title, summary FROM sessions WHERE ...` |
-| Find what was done before | `oak ci memories` / `sqlite3` | "what did we decide about caching?" |
+| Find what was done before | `{oak-cli-command} ci memories` / `sqlite3` | "what did we decide about caching?" |
 | Query session history | `sqlite3 -readonly` | `SELECT * FROM sessions ORDER BY ...` |
 | Aggregate usage stats | `sqlite3 -readonly` | `SELECT agent_name, sum(cost_usd) FROM agent_runs ...` |
-| Run automated analysis | `oak ci agent run` | `oak ci agent run usage-report` |
+| Run automated analysis | `{oak-cli-command} ci agent run` | `{oak-cli-command} ci agent run usage-report` |
 
 ## Why Semantic Search Over Grep
 
@@ -217,10 +217,10 @@ ORDER BY next_run_at_epoch;
 For automated analysis that runs queries and produces reports:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+{oak-cli-command} ci agent run usage-report              # Cost and token usage trends
+{oak-cli-command} ci agent run productivity-report       # Session quality and error rates
+{oak-cli-command} ci agent run codebase-activity-report  # File hotspots and tool patterns
+{oak-cli-command} ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/src/open_agent_kit/features/codebase_intelligence/skills/codebase-intelligence/references/analysis-playbooks.md
+++ b/src/open_agent_kit/features/codebase_intelligence/skills/codebase-intelligence/references/analysis-playbooks.md
@@ -2,7 +2,7 @@
 
 Structured multi-query workflows for analyzing CI data. Each playbook is a sequence of queries that build on each other to answer a specific question.
 
-These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`oak ci agent run <task-name>`).
+These playbooks can be used manually via the `codebase-intelligence` skill, or automated via the analysis agent (`{oak-cli-command} ci agent run <task-name>`).
 
 ## Playbook 1: Usage & Cost Analysis
 
@@ -223,10 +223,10 @@ LIMIT 10;
 These playbooks can be run automatically via the analysis agent:
 
 ```bash
-oak ci agent run usage-report          # Playbook 1
-oak ci agent run productivity-report   # Playbook 2
-oak ci agent run codebase-activity-report  # Playbook 3
-oak ci agent run prompt-analysis       # Playbook 4
+{oak-cli-command} ci agent run usage-report          # Playbook 1
+{oak-cli-command} ci agent run productivity-report   # Playbook 2
+{oak-cli-command} ci agent run codebase-activity-report  # Playbook 3
+{oak-cli-command} ci agent run prompt-analysis       # Playbook 4
 ```
 
 Reports are written to `oak/insights/` and can be committed to git for team visibility.

--- a/src/open_agent_kit/features/codebase_intelligence/skills/codebase-intelligence/references/finding-related-code.md
+++ b/src/open_agent_kit/features/codebase_intelligence/skills/codebase-intelligence/references/finding-related-code.md
@@ -29,39 +29,39 @@ Use this workflow when:
 
 ```bash
 # Find code related to a concept
-oak ci search "form validation logic" --type code
+{oak-cli-command} ci search "form validation logic" --type code
 
 # Find similar patterns
-oak ci search "retry with exponential backoff" --type code
+{oak-cli-command} ci search "retry with exponential backoff" --type code
 
 # More results for broader exploration
-oak ci search "error handling and logging" --type code -n 20
+{oak-cli-command} ci search "error handling and logging" --type code -n 20
 ```
 
 ### Discover component relationships
 
 ```bash
 # Find code related to two concepts (relationship)
-oak ci search "how does AuthService interact with TokenManager"
+{oak-cli-command} ci search "how does AuthService interact with TokenManager"
 
 # Search for data flow patterns
-oak ci search "order creation inventory update"
+{oak-cli-command} ci search "order creation inventory update"
 
 # Get context about a specific relationship
-oak ci context "relationship between UserService and PaymentProcessor"
+{oak-cli-command} ci context "relationship between UserService and PaymentProcessor"
 ```
 
 ### Get context for current work
 
 ```bash
 # Find code related to files you're editing
-oak ci context "similar implementations" -f src/services/user.py
+{oak-cli-command} ci context "similar implementations" -f src/services/user.py
 
 # Find related code for a specific task
-oak ci context "validation patterns" -f src/api/handlers.py
+{oak-cli-command} ci context "validation patterns" -f src/api/handlers.py
 
 # Get context with specific files in focus
-oak ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
+{oak-cli-command} ci context "how auth middleware relates to session handling" -f src/middleware/auth.py
 ```
 
 ## Example: Finding Similar Implementations
@@ -70,13 +70,13 @@ oak ci context "how auth middleware relates to session handling" -f src/middlewa
 
 ```bash
 # 1. Find existing endpoint implementations
-oak ci search "REST API endpoint handler" --type code
+{oak-cli-command} ci search "REST API endpoint handler" --type code
 
 # 2. Find validation patterns
-oak ci search "input validation for API requests" --type code
+{oak-cli-command} ci search "input validation for API requests" --type code
 
 # 3. Find error handling patterns
-oak ci search "API error response formatting" --type code
+{oak-cli-command} ci search "API error response formatting" --type code
 ```
 
 **What you'll find**: Consistent patterns used elsewhere, even if the endpoints are in different modules or use different naming conventions.
@@ -92,7 +92,7 @@ oak ci search "API error response formatting" --type code
 # - "token_refresh" (authentication adjacent)
 
 # Semantic search finds them all:
-oak ci search "user authentication and authorization" --type code -n 20
+{oak-cli-command} ci search "user authentication and authorization" --type code -n 20
 ```
 
 ## Example: Understanding Component Relationships
@@ -101,13 +101,13 @@ oak ci search "user authentication and authorization" --type code -n 20
 
 ```bash
 # 1. Search for code mentioning both concepts
-oak ci search "OrderService inventory management"
+{oak-cli-command} ci search "OrderService inventory management"
 
 # 2. Get broader context
-oak ci context "relationship between orders and inventory"
+{oak-cli-command} ci context "relationship between orders and inventory"
 
 # 3. Search for data flow patterns
-oak ci search "order creation inventory update"
+{oak-cli-command} ci search "order creation inventory update"
 ```
 
 **What you'll find**: Semantic search reveals event handlers, shared models, and integration points that aren't obvious from imports alone.
@@ -120,7 +120,7 @@ oak ci search "order creation inventory update"
 - Increase `-n` limit when exploring broadly
 - Use `--type code` to focus on implementation (exclude memories)
 - Combine multiple searches to build complete picture
-- Combine with `oak ci context` for richer understanding
+- Combine with `{oak-cli-command} ci context` for richer understanding
 
 ## Output
 
@@ -131,8 +131,8 @@ Results include:
 
 ```bash
 # JSON output (default) - good for parsing
-oak ci search "database transactions" -f json
+{oak-cli-command} ci search "database transactions" -f json
 
 # Text output - good for reading
-oak ci search "database transactions" -f text
+{oak-cli-command} ci search "database transactions" -f text
 ```

--- a/src/open_agent_kit/features/codebase_intelligence/skills/codebase-intelligence/references/impact-analysis.md
+++ b/src/open_agent_kit/features/codebase_intelligence/skills/codebase-intelligence/references/impact-analysis.md
@@ -22,23 +22,23 @@ Semantic search finds code related by meaning. When you change how something wor
 
 ```bash
 # Find all code related to what you're changing
-oak ci search "AuthService token validation" --type code -n 20
+{oak-cli-command} ci search "AuthService token validation" --type code -n 20
 
 # Get impact context for a specific file
-oak ci context "impact of changes" -f src/services/auth.py
+{oak-cli-command} ci context "impact of changes" -f src/services/auth.py
 
 # Search for code using similar patterns
-oak ci search "code that depends on JWT token format" --type code
+{oak-cli-command} ci search "code that depends on JWT token format" --type code
 ```
 
 ### Check for related memories
 
 ```bash
 # Find past learnings that might be relevant
-oak ci search "gotchas with auth changes" --type memory
+{oak-cli-command} ci search "gotchas with auth changes" --type memory
 
 # Find decisions that might be affected
-oak ci search "decisions about token handling"
+{oak-cli-command} ci search "decisions about token handling"
 ```
 
 ## Example: Before Refactoring
@@ -47,16 +47,16 @@ oak ci search "decisions about token handling"
 
 ```bash
 # 1. Find all code conceptually related to payment processing
-oak ci search "payment processing flow" --type code -n 20
+{oak-cli-command} ci search "payment processing flow" --type code -n 20
 
 # 2. Find code that handles payment errors (often missed)
-oak ci search "payment error handling and recovery" --type code
+{oak-cli-command} ci search "payment error handling and recovery" --type code
 
 # 3. Find related integrations
-oak ci search "payment gateway integration" --type code
+{oak-cli-command} ci search "payment gateway integration" --type code
 
 # 4. Check for past issues/decisions
-oak ci search "payment processing gotchas" --type memory
+{oak-cli-command} ci search "payment processing gotchas" --type memory
 ```
 
 **What you'll find**:
@@ -74,25 +74,25 @@ Many of these won't show up in import analysis!
 
 ```bash
 # Find all code that might parse this response
-oak ci search "user API response handling" --type code
+{oak-cli-command} ci search "user API response handling" --type code
 
 # Find frontend code consuming this API
-oak ci search "fetch user data from API" --type code
+{oak-cli-command} ci search "fetch user data from API" --type code
 
 # Find tests that might break
-oak ci search "user API endpoint tests" --type code
+{oak-cli-command} ci search "user API endpoint tests" --type code
 
 # Check for integration patterns
-oak ci context "code that depends on user API format"
+{oak-cli-command} ci context "code that depends on user API format"
 ```
 
 ## Impact Analysis Workflow
 
 1. **Identify the change**: What are you modifying?
-2. **Search for direct usage**: `oak ci search "ComponentName" --type code`
-3. **Search for conceptual usage**: `oak ci search "what ComponentName does" --type code`
-4. **Check for patterns**: `oak ci search "code using similar patterns" --type code`
-5. **Review memories**: `oak ci search "past issues with this area" --type memory`
+2. **Search for direct usage**: `{oak-cli-command} ci search "ComponentName" --type code`
+3. **Search for conceptual usage**: `{oak-cli-command} ci search "what ComponentName does" --type code`
+4. **Check for patterns**: `{oak-cli-command} ci search "code using similar patterns" --type code`
+5. **Review memories**: `{oak-cli-command} ci search "past issues with this area" --type memory`
 6. **Read the results**: Assess which code might need updates
 
 ## Tips
@@ -101,4 +101,4 @@ oak ci context "code that depends on user API format"
 - Search for what the code *does*, not just its name
 - Include error handling and edge cases in your search
 - Check memories for past issues in this area
-- Use `oak ci context` with the file you're changing for focused results
+- Use `{oak-cli-command} ci context` with the file you're changing for focused results

--- a/src/open_agent_kit/features/codebase_intelligence/skills/codebase-intelligence/references/querying-databases.md
+++ b/src/open_agent_kit/features/codebase_intelligence/skills/codebase-intelligence/references/querying-databases.md
@@ -19,7 +19,7 @@ Use direct SQL when browsing the dashboard is insufficient and detailed analysis
 - Full-text keyword search (FTS5 `MATCH` — different from semantic vector search)
 - When the CI daemon is not running (SQLite is always readable directly)
 
-**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `oak ci remember`.
+**Never write to the database directly.** Always use `-readonly` with `sqlite3`. To store memories, use `oak_remember` or `{oak-cli-command} ci remember`.
 
 ## Database Location
 
@@ -69,13 +69,13 @@ For everyday codebase intelligence (semantic search, storing memories, retrievin
 
 | MCP Tool | CLI Equivalent | Purpose |
 |----------|---------------|---------|
-| `oak_search` | `oak ci search "query"` | Semantic vector search (code, memories, plans) |
-| `oak_remember` | `oak ci remember "observation"` | Store a memory or learning |
-| `oak_context` | `oak ci context "task"` | Get task-relevant context |
-| — | `oak ci memories --type gotcha` | Browse memories by type |
-| — | `oak ci sessions` | List session summaries |
+| `oak_search` | `{oak-cli-command} ci search "query"` | Semantic vector search (code, memories, plans) |
+| `oak_remember` | `{oak-cli-command} ci remember "observation"` | Store a memory or learning |
+| `oak_context` | `{oak-cli-command} ci context "task"` | Get task-relevant context |
+| — | `{oak-cli-command} ci memories --type gotcha` | Browse memories by type |
+| — | `{oak-cli-command} ci sessions` | List session summaries |
 
-Check daemon status with `oak ci status`. Start with `oak ci start` if needed.
+Check daemon status with `{oak-cli-command} ci status`. Start with `{oak-cli-command} ci start` if needed.
 
 ## Important Notes
 
@@ -99,10 +99,10 @@ For complete schema DDL and advanced query patterns, consult:
 For automated analysis that runs these queries and produces reports, use the analysis agent:
 
 ```bash
-oak ci agent run usage-report              # Cost and token usage trends
-oak ci agent run productivity-report       # Session quality and error rates
-oak ci agent run codebase-activity-report  # File hotspots and tool patterns
-oak ci agent run prompt-analysis           # Prompt quality and recommendations
+{oak-cli-command} ci agent run usage-report              # Cost and token usage trends
+{oak-cli-command} ci agent run productivity-report       # Session quality and error rates
+{oak-cli-command} ci agent run codebase-activity-report  # File hotspots and tool patterns
+{oak-cli-command} ci agent run prompt-analysis           # Prompt quality and recommendations
 ```
 
 Reports are written to `oak/insights/` (git-tracked, team-shareable).

--- a/src/open_agent_kit/features/core/agent-settings/claude-settings.json
+++ b/src/open_agent_kit/features/core/agent-settings/claude-settings.json
@@ -1,9 +1,9 @@
 {
-  "$comment": "Claude Code auto-approval settings for oak commands",
+  "$comment": "Claude Code auto-approval settings for OAK CLI command.",
   "permissions": {
     "allow": [
-      "Bash(oak:*)",
-      "Bash(oak *)"
+      "Bash({oak-cli-command}:*)",
+      "Bash({oak-cli-command} *)"
     ]
   }
 }

--- a/src/open_agent_kit/features/core/agent-settings/copilot-settings.json
+++ b/src/open_agent_kit/features/core/agent-settings/copilot-settings.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "GitHub Copilot auto-approval settings for oak commands. Uses chat.tools.terminal.autoApprove (available in VS Code 1.99+).",
+  "$comment": "GitHub Copilot auto-approval settings for OAK CLI command. Uses chat.tools.terminal.autoApprove (available in VS Code 1.99+).",
   "chat.tools.terminal.autoApprove": {
-    "oak": true
+    "{oak-cli-command}": true
   }
 }

--- a/src/open_agent_kit/features/core/agent-settings/cursor-settings.json
+++ b/src/open_agent_kit/features/core/agent-settings/cursor-settings.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Cursor agent auto-approval settings for oak commands. Note: This overlaps with IDE settings - both use the same file.",
+  "$comment": "Cursor agent auto-approval settings for OAK CLI command. Note: This overlaps with IDE settings - both use the same file.",
   "chat.tools.terminal.autoApprove": {
-    "oak": true
+    "{oak-cli-command}": true
   }
 }

--- a/src/open_agent_kit/features/core/agent-settings/gemini-settings.json
+++ b/src/open_agent_kit/features/core/agent-settings/gemini-settings.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Gemini CLI auto-approval settings for oak commands",
+  "$comment": "Gemini CLI auto-approval settings for OAK CLI command.",
   "coreTools": [
-    "ShellTool(oak *)"
+    "ShellTool({oak-cli-command} *)"
   ]
 }

--- a/src/open_agent_kit/features/core/agent-settings/opencode-settings.json
+++ b/src/open_agent_kit/features/core/agent-settings/opencode-settings.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "$comment": "OpenCode auto-approval settings for oak commands. These permissions allow oak CLI commands to run without prompting.",
+  "$comment": "OpenCode auto-approval settings for OAK CLI command. These permissions allow OAK CLI commands to run without prompting.",
   "permission": {
     "bash": {
-      "oak *": "allow"
+      "{oak-cli-command} *": "allow"
     }
   }
 }

--- a/src/open_agent_kit/features/core/agent-settings/windsurf-settings.json
+++ b/src/open_agent_kit/features/core/agent-settings/windsurf-settings.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Windsurf Cascade auto-approval settings for oak commands. Uses cascadeCommandsAllowList to auto-execute oak commands without prompting.",
+  "$comment": "Windsurf Cascade auto-approval settings for OAK CLI command. Uses cascadeCommandsAllowList to auto-execute OAK CLI commands without prompting.",
   "windsurf.cascadeCommandsAllowList": [
-    "oak"
+    "{oak-cli-command}"
   ]
 }

--- a/src/open_agent_kit/features/rules_management/skills/project-governance/SKILL.md
+++ b/src/open_agent_kit/features/rules_management/skills/project-governance/SKILL.md
@@ -26,16 +26,16 @@ Create, modify, and maintain project constitutions, agent instruction files, and
 ### Create an RFC
 
 ```bash
-oak rfc create --title "Add caching layer" --template feature
-oak rfc list
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+{oak-cli-command} rfc create --title "Add caching layer" --template feature
+{oak-cli-command} rfc list
+{oak-cli-command} rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ### Sync agent instruction files
 
 ```bash
-oak rules sync-agents          # Sync constitution references to all agent files
-oak rules detect-existing      # Discover all configured agent instruction files
+{oak-cli-command} rules sync-agents          # Sync constitution references to all agent files
+{oak-cli-command} rules detect-existing      # Discover all configured agent instruction files
 ```
 
 ## Commands Reference
@@ -44,21 +44,21 @@ oak rules detect-existing      # Discover all configured agent instruction files
 
 | Command | Purpose |
 |---------|---------|
-| `oak rules sync-agents` | Sync constitution references to all agent instruction files |
-| `oak rules sync-agents --dry-run` | Preview what files will be checked/updated |
-| `oak rules detect-existing` | Discover all configured agent instruction files |
-| `oak rules detect-existing --json` | Machine-readable output of agent files |
+| `{oak-cli-command} rules sync-agents` | Sync constitution references to all agent instruction files |
+| `{oak-cli-command} rules sync-agents --dry-run` | Preview what files will be checked/updated |
+| `{oak-cli-command} rules detect-existing` | Discover all configured agent instruction files |
+| `{oak-cli-command} rules detect-existing --json` | Machine-readable output of agent files |
 
 ### RFC commands
 
 | Command | Purpose |
 |---------|---------|
-| `oak rfc create --title "..." --template <type>` | Create a new RFC |
-| `oak rfc list` | List all RFCs |
-| `oak rfc validate <path>` | Validate RFC structure and content |
-| `oak rfc show <path>` | Show RFC details |
-| `oak rfc adopt <path>` | Mark RFC as adopted |
-| `oak rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
+| `{oak-cli-command} rfc create --title "..." --template <type>` | Create a new RFC |
+| `{oak-cli-command} rfc list` | List all RFCs |
+| `{oak-cli-command} rfc validate <path>` | Validate RFC structure and content |
+| `{oak-cli-command} rfc show <path>` | Show RFC details |
+| `{oak-cli-command} rfc adopt <path>` | Mark RFC as adopted |
+| `{oak-cli-command} rfc abandon <path> --reason "..."` | Mark RFC as abandoned |
 
 ## When to Use
 
@@ -98,16 +98,16 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 
 1. **Read** the current constitution (`oak/constitution.md`)
 2. **Add** the full rule to the appropriate section using RFC 2119 language (MUST, SHOULD, MAY)
-3. **Sync** to all agent files: `oak rules sync-agents`
+3. **Sync** to all agent files: `{oak-cli-command} rules sync-agents`
 
 **CRITICAL:** Rules MUST be added to the constitution FIRST, then synced to agent files. Never add a rule only to an agent file.
 
 ### RFC lifecycle
 
-1. **Create**: `oak rfc create --title "..." --template feature --author "Name"`
+1. **Create**: `{oak-cli-command} rfc create --title "..." --template feature --author "Name"`
 2. **Fill in**: Problem context, proposed solution, trade-offs, alternatives
 3. **Review**: Use the review checklist (see `references/reviewing-rfcs.md`)
-4. **Adopt or abandon**: `oak rfc adopt <path>` or `oak rfc abandon <path> --reason "..."`
+4. **Adopt or abandon**: `{oak-cli-command} rfc adopt <path>` or `{oak-cli-command} rfc abandon <path> --reason "..."`
 
 ### RFC review checklist (summary)
 
@@ -131,7 +131,7 @@ Required sections: Metadata, Scope and Non-Goals, Golden Paths with Anchor Index
 ## Files
 
 - Constitution: `oak/constitution.md` or `.constitution.md`
-- Agent files: Run `oak rules detect-existing` to discover all agent instruction files
+- Agent files: Run `{oak-cli-command} rules detect-existing` to discover all agent instruction files
 - RFCs: `oak/rfc/RFC-XXX-short-title.md`
 
 ## Deep Dives

--- a/src/open_agent_kit/features/rules_management/skills/project-governance/references/agent-files-guide.md
+++ b/src/open_agent_kit/features/rules_management/skills/project-governance/references/agent-files-guide.md
@@ -15,7 +15,7 @@ Agent instruction files are **short, operational documents** that:
 ### Option 1: Use OAK's sync command
 
 ```bash
-oak rules sync-agents
+{oak-cli-command} rules sync-agents
 ```
 
 ### Option 2: Create manually
@@ -65,8 +65,8 @@ Do NOT hardcode agent file names. Use OAK's built-in commands:
 
 ```bash
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+{oak-cli-command} rules detect-existing
+{oak-cli-command} rules detect-existing --json  # machine-readable output
 ```
 
 Agent files are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -77,10 +77,10 @@ When the constitution is updated, sync changes to all agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+{oak-cli-command} rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+{oak-cli-command} rules sync-agents
 ```
 
 ## What Makes a Good Agent File

--- a/src/open_agent_kit/features/rules_management/skills/project-governance/references/constitution-guide.md
+++ b/src/open_agent_kit/features/rules_management/skills/project-governance/references/constitution-guide.md
@@ -116,7 +116,7 @@ Create `oak/constitution.md` (or `.constitution.md` at root):
 After creating the constitution, create agent files that reference it:
 
 ```bash
-oak rules sync-agents
+{oak-cli-command} rules sync-agents
 ```
 
 ## Adding Rules to Existing Constitution
@@ -130,8 +130,8 @@ oak rules sync-agents
 cat oak/constitution.md  # or .constitution.md
 
 # Discover all agent instruction files dynamically
-oak rules detect-existing
-oak rules detect-existing --json  # machine-readable output
+{oak-cli-command} rules detect-existing
+{oak-cli-command} rules detect-existing --json  # machine-readable output
 ```
 
 **Do NOT hardcode agent file names.** Agents are configured dynamically in `.oak/config.yaml` and each agent's manifest defines its own `installation.instruction_file` path.
@@ -168,13 +168,13 @@ After the constitution is updated, sync to all configured agent files:
 
 ```bash
 # Preview what files will be checked/updated
-oak rules sync-agents --dry-run
+{oak-cli-command} rules sync-agents --dry-run
 
 # Sync constitution references to all agent files
-oak rules sync-agents
+{oak-cli-command} rules sync-agents
 ```
 
-If manual updates are needed, use `oak rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
+If manual updates are needed, use `{oak-cli-command} rules detect-existing --json` to get the full list of agent files. For each file, add a concise reference:
 
 ```markdown
 ## [Rule Name]
@@ -182,7 +182,7 @@ If manual updates are needed, use `oak rules detect-existing --json` to get the 
 **MUST NOT** [brief prohibition]. See §[section] of `oak/constitution.md` for the full rule, rationale, and verification command.
 ```
 
-**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `oak rules detect-existing`.
+**Important:** Agent instruction file paths are defined in each agent's manifest (`installation.instruction_file`). Do not assume fixed file names — always discover dynamically via `{oak-cli-command} rules detect-existing`.
 
 ## Example Workflow
 
@@ -196,4 +196,4 @@ User: "We need to establish coding standards for this Python project"
    - Quality gate (`make check` or equivalent)
    - Anchor files (point to best existing modules)
 3. **Create agent files** referencing the constitution
-4. **Sync**: `oak rules sync-agents`
+4. **Sync**: `{oak-cli-command} rules sync-agents`

--- a/src/open_agent_kit/features/rules_management/skills/project-governance/references/creating-rfcs.md
+++ b/src/open_agent_kit/features/rules_management/skills/project-governance/references/creating-rfcs.md
@@ -22,13 +22,13 @@ Use this workflow when:
 
 ```bash
 # Create an RFC interactively
-oak rfc create --title "Add caching layer" --template feature
+{oak-cli-command} rfc create --title "Add caching layer" --template feature
 
 # List existing RFCs
-oak rfc list
+{oak-cli-command} rfc list
 
 # Validate an RFC
-oak rfc validate oak/rfc/RFC-001-add-caching-layer.md
+{oak-cli-command} rfc validate oak/rfc/RFC-001-add-caching-layer.md
 ```
 
 ## RFC Templates
@@ -70,7 +70,7 @@ What else did we consider? Why not those?
 ### 1. Create the RFC
 
 ```bash
-oak rfc create --title "Your RFC Title" --template feature --author "Your Name"
+{oak-cli-command} rfc create --title "Your RFC Title" --template feature --author "Your Name"
 ```
 
 This creates a file in `oak/rfc/` with the proper structure.
@@ -88,13 +88,13 @@ Edit the generated file to add:
 The RFC is now ready for team review. Once approved:
 
 ```bash
-oak rfc adopt oak/rfc/RFC-XXX-your-rfc.md
+{oak-cli-command} rfc adopt oak/rfc/RFC-XXX-your-rfc.md
 ```
 
 Or if abandoned:
 
 ```bash
-oak rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
+{oak-cli-command} rfc abandon oak/rfc/RFC-XXX-your-rfc.md --reason "Superseded by RFC-YYY"
 ```
 
 ## Tips

--- a/src/open_agent_kit/features/rules_management/skills/project-governance/references/reviewing-rfcs.md
+++ b/src/open_agent_kit/features/rules_management/skills/project-governance/references/reviewing-rfcs.md
@@ -21,13 +21,13 @@ Use this workflow when:
 
 ```bash
 # List all RFCs
-oak rfc list
+{oak-cli-command} rfc list
 
 # Validate a specific RFC
-oak rfc validate oak/rfc/RFC-001-your-rfc.md
+{oak-cli-command} rfc validate oak/rfc/RFC-001-your-rfc.md
 
 # Show RFC details
-oak rfc show oak/rfc/RFC-001-your-rfc.md
+{oak-cli-command} rfc show oak/rfc/RFC-001-your-rfc.md
 ```
 
 ## Review Checklist
@@ -88,7 +88,7 @@ When providing feedback, structure it as:
 Run automated validation:
 
 ```bash
-oak rfc validate oak/rfc/RFC-XXX-title.md
+{oak-cli-command} rfc validate oak/rfc/RFC-XXX-title.md
 ```
 
 This checks:
@@ -111,5 +111,5 @@ This checks:
 RFCs are in `oak/rfc/` directory. List all with:
 
 ```bash
-oak rfc list
+{oak-cli-command} rfc list
 ```

--- a/src/open_agent_kit/services/agent_settings_service.py
+++ b/src/open_agent_kit/services/agent_settings_service.py
@@ -25,6 +25,10 @@ from typing import Any
 import yaml
 
 from open_agent_kit.config.paths import FEATURES_DIR
+from open_agent_kit.features.codebase_intelligence.cli_command import (
+    render_cli_command_placeholder,
+    resolve_ci_cli_command,
+)
 from open_agent_kit.utils import (
     cleanup_empty_directories,
     ensure_dir,
@@ -62,6 +66,7 @@ class AgentSettingsService:
         self.agents_dir = AGENTS_DIR
         # Path: services/agent_settings_service.py -> services/ -> open_agent_kit/
         self.core_dir = Path(__file__).parent.parent / FEATURES_DIR / "core"
+        self.cli_command = resolve_ci_cli_command(self.project_root)
 
         # Cache for loaded manifests
         self._manifest_cache: dict[str, dict[str, Any]] = {}
@@ -156,6 +161,7 @@ class AgentSettingsService:
 
         try:
             content = read_file(template_path)
+            content = render_cli_command_placeholder(content, self.cli_command)
             result: dict[str, Any] = json.loads(content)
             return result
         except (json.JSONDecodeError, OSError) as e:

--- a/src/open_agent_kit/services/upgrade_service.py
+++ b/src/open_agent_kit/services/upgrade_service.py
@@ -804,8 +804,10 @@ class UpgradeService:
                 # moving from .agent/skills/ to .gemini/skills/). Needs reinstall.
                 return True
 
-            # Compare directory contents - if any agent has outdated content, needs upgrade
-            if self._skill_dirs_differ(package_skill_dir, installed_skill_dir):
+            # Compare directory contents after CLI-aware rendering.
+            # This prevents perpetual upgrades when installed skills use a
+            # configured CLI command (e.g. oak-dev) and package assets use oak.
+            if skill_service.skill_dirs_differ(package_skill_dir, installed_skill_dir):
                 return True
 
         return False

--- a/tests/test_agent_settings_service.py
+++ b/tests/test_agent_settings_service.py
@@ -1,0 +1,55 @@
+"""Tests for agent settings template rendering and guardrails."""
+
+from pathlib import Path
+
+from open_agent_kit.features.codebase_intelligence.cli_command import CLI_COMMAND_PLACEHOLDER
+from open_agent_kit.services.agent_settings_service import AgentSettingsService
+
+AGENT_SETTINGS_DIR = Path("src/open_agent_kit/features/core/agent-settings")
+AGENT_SETTINGS_JSON_GLOB = "*.json"
+TEST_CLI_COMMAND = "oak-dev"
+CLAUDE_TEMPLATE_KEY = "agent-settings/claude-settings.json"
+
+HARDCODED_AGENT_SETTINGS_PATTERNS = (
+    "Bash(oak:*)",
+    "Bash(oak *)",
+    "ShellTool(oak *)",
+    '"oak *": "allow"',
+    '"oak": true',
+    '"oak"',
+)
+
+
+def test_agent_settings_template_renders_cli_command_placeholder(tmp_path: Path) -> None:
+    """Agent settings templates should render the configured CLI command."""
+    service = AgentSettingsService(project_root=tmp_path)
+    service.cli_command = TEST_CLI_COMMAND
+
+    service._get_auto_approve_config = lambda _agent: {  # type: ignore[method-assign]
+        "enabled": True,
+        "template": CLAUDE_TEMPLATE_KEY,
+    }
+
+    template = service._load_template("claude")
+
+    assert template is not None
+    allowlist = template["permissions"]["allow"]
+    assert f"Bash({TEST_CLI_COMMAND}:*)" in allowlist
+    assert f"Bash({TEST_CLI_COMMAND} *)" in allowlist
+
+
+def test_agent_settings_templates_use_cli_command_placeholder() -> None:
+    """Managed agent settings templates must use explicit CLI command placeholders."""
+    errors: list[str] = []
+
+    for template_path in sorted(AGENT_SETTINGS_DIR.glob(AGENT_SETTINGS_JSON_GLOB)):
+        text = template_path.read_text(encoding="utf-8")
+
+        if CLI_COMMAND_PLACEHOLDER not in text:
+            errors.append(f"{template_path}: missing {CLI_COMMAND_PLACEHOLDER}")
+
+        for pattern in HARDCODED_AGENT_SETTINGS_PATTERNS:
+            if pattern in text:
+                errors.append(f"{template_path}: contains hardcoded command pattern {pattern!r}")
+
+    assert not errors, "Use '{oak-cli-command}' placeholder in:\n" + "\n".join(errors)

--- a/tests/unit/features/codebase_intelligence/notifications/test_installer.py
+++ b/tests/unit/features/codebase_intelligence/notifications/test_installer.py
@@ -1,0 +1,46 @@
+"""Tests for notification installer CLI command rendering."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from open_agent_kit.features.codebase_intelligence.cli_command import CLI_COMMAND_PLACEHOLDER
+from open_agent_kit.features.codebase_intelligence.notifications.installer import (
+    NotificationsInstaller,
+)
+
+
+def test_render_notify_config_renders_configured_cli_command(tmp_path: Path) -> None:
+    """Notify config rendering should use configured CLI executable."""
+    installer = NotificationsInstaller(tmp_path, "codex")
+    installer.cli_command = "oak-dev"
+
+    notify_config = MagicMock()
+    notify_config.command = "oak"
+    notify_config.args = ["ci", "notify", "--agent", "codex"]
+    notify_config.script_template = None
+    notify_config.script_path = None
+    notify_config.enabled = True
+    notify_config.config_key = "notify"
+
+    notifications_config = MagicMock()
+    notifications_config.notify = notify_config
+    installer._notifications_config = notifications_config
+
+    template_path = tmp_path / "notify_config.toml.j2"
+    template_path.write_text(
+        'notify = ["{oak-cli-command}"{% for arg in notify_args %}, "{{ arg }}"{% endfor %}]'
+    )
+
+    rendered = installer._render_notify_config(template_path, script_path=None)
+    assert rendered["notify"][0] == "oak-dev"
+
+
+def test_notify_template_uses_cli_command_placeholder() -> None:
+    """Notify template must use the explicit CLI command placeholder."""
+    template_path = Path(
+        "src/open_agent_kit/features/codebase_intelligence/notifications/codex/notify_config.toml.j2"
+    )
+    template_content = template_path.read_text(encoding="utf-8")
+
+    assert CLI_COMMAND_PLACEHOLDER in template_content
+    assert '"oak"' not in template_content

--- a/tests/unit/features/codebase_intelligence/test_cli_command.py
+++ b/tests/unit/features/codebase_intelligence/test_cli_command.py
@@ -1,0 +1,48 @@
+"""Tests for CI CLI command resolution and rewrite helpers."""
+
+from pathlib import Path
+
+import yaml
+
+from open_agent_kit.features.codebase_intelligence.cli_command import (
+    resolve_ci_cli_command,
+    rewrite_oak_command,
+)
+from open_agent_kit.features.codebase_intelligence.constants import (
+    CI_CLI_COMMAND_DEFAULT,
+)
+
+
+def test_resolve_cli_command_defaults_when_not_configured(tmp_path: Path) -> None:
+    """Resolver should return default command when config is absent."""
+    assert resolve_ci_cli_command(tmp_path) == CI_CLI_COMMAND_DEFAULT
+
+
+def test_resolve_cli_command_from_project_config(tmp_path: Path) -> None:
+    """Resolver should return configured project command."""
+    oak_dir = tmp_path / ".oak"
+    oak_dir.mkdir(parents=True)
+    config_path = oak_dir / "config.yaml"
+    config_path.write_text(
+        yaml.dump(
+            {"codebase_intelligence": {"cli_command": "oak-dev"}},
+            sort_keys=False,
+        )
+    )
+
+    assert resolve_ci_cli_command(tmp_path) == "oak-dev"
+
+
+def test_rewrite_oak_command_rewrites_root_command() -> None:
+    """Rewriter should transform plain ``oak`` command."""
+    assert rewrite_oak_command("oak", "oak-dev") == "oak-dev"
+
+
+def test_rewrite_oak_command_rewrites_prefixed_command() -> None:
+    """Rewriter should transform ``oak ...`` command prefix."""
+    assert rewrite_oak_command("oak ci mcp", "oak-dev") == "oak-dev ci mcp"
+
+
+def test_rewrite_oak_command_keeps_non_oak_commands() -> None:
+    """Rewriter should preserve non-oak commands."""
+    assert rewrite_oak_command("python -m app", "oak-dev") == "python -m app"

--- a/tests/unit/features/codebase_intelligence/test_config.py
+++ b/tests/unit/features/codebase_intelligence/test_config.py
@@ -29,6 +29,7 @@ from open_agent_kit.features.codebase_intelligence.config import (
     save_ci_config,
 )
 from open_agent_kit.features.codebase_intelligence.constants import (
+    CI_CLI_COMMAND_DEFAULT,
     DEFAULT_BASE_URL,
     DEFAULT_MODEL,
     DEFAULT_PROVIDER,
@@ -385,6 +386,7 @@ class TestCIConfigInit:
         assert isinstance(default_ci_config.embedding, EmbeddingConfig)
         assert default_ci_config.index_on_startup is True
         assert default_ci_config.watch_files is True
+        assert default_ci_config.cli_command == CI_CLI_COMMAND_DEFAULT
         assert default_ci_config.log_level == LOG_LEVEL_INFO
 
     def test_init_with_custom_values(self, custom_ci_config: CIConfig):
@@ -422,6 +424,12 @@ class TestCIConfigValidation:
         with pytest.raises(ValidationError) as exc_info:
             CIConfig(log_level="INVALID_LEVEL")
         assert "Invalid log level" in str(exc_info.value)
+
+    def test_invalid_cli_command_raises_error(self):
+        """Test that invalid CLI executable names are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            CIConfig(cli_command="oak dev")
+        assert "Invalid CLI command" in str(exc_info.value)
 
     @pytest.mark.parametrize(
         "valid_level",
@@ -502,6 +510,7 @@ class TestCIConfigFromDict:
         config = CIConfig.from_dict({})
         assert config.index_on_startup is True
         assert config.watch_files is True
+        assert config.cli_command == CI_CLI_COMMAND_DEFAULT
         assert config.log_level == LOG_LEVEL_INFO
 
     def test_from_dict_with_custom_values(self):
@@ -541,6 +550,7 @@ class TestCIConfigToDict:
         recreated = CIConfig.from_dict(dict_repr)
         assert recreated.index_on_startup == custom_ci_config.index_on_startup
         assert recreated.watch_files == custom_ci_config.watch_files
+        assert recreated.cli_command == custom_ci_config.cli_command
         assert recreated.log_level == custom_ci_config.log_level
 
 


### PR DESCRIPTION
This pull request updates all references from `oak ci` to `oak-dev ci` across configuration files and documentation related to codebase intelligence and CI workflows. The changes ensure consistency and accuracy in CLI commands, hooks, and documentation for the development environment.

Configuration updates:

* [`.claude/settings.json`](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L9-R9): Changed all CI hook commands from `oak ci hook ...` to `oak-dev ci hook ...` for session, tool use, agent, and memory hooks, ensuring the configuration uses the correct CLI for the development environment. [[1]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L9-R9) [[2]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L21-R21) [[3]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L33-R33) [[4]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L45-R45) [[5]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L57-R57) [[6]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L69-R69) [[7]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L81-R81) [[8]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L93-R93)

Documentation and skill usage updates:

* [`.claude/skills/codebase-intelligence/SKILL.md`](diffhunk://#diff-33a4283642854533cf951ea43ecc8cb2be25f15c423cad8d3be4c55fbf185968L11-R11): Updated all CLI usage examples, tool descriptions, and tables to use `oak-dev ci` instead of `oak ci`, including memory storage, semantic search, session management, and automated analysis commands. [[1]](diffhunk://#diff-33a4283642854533cf951ea43ecc8cb2be25f15c423cad8d3be4c55fbf185968L11-R11) [[2]](diffhunk://#diff-33a4283642854533cf951ea43ecc8cb2be25f15c423cad8d3be4c55fbf185968L26-R39) [[3]](diffhunk://#diff-33a4283642854533cf951ea43ecc8cb2be25f15c423cad8d3be4c55fbf185968L50-R53) [[4]](diffhunk://#diff-33a4283642854533cf951ea43ecc8cb2be25f15c423cad8d3be4c55fbf185968L69-R84) [[5]](diffhunk://#diff-33a4283642854533cf951ea43ecc8cb2be25f15c423cad8d3be4c55fbf185968L96-R104) [[6]](diffhunk://#diff-33a4283642854533cf951ea43ecc8cb2be25f15c423cad8d3be4c55fbf185968L220-R223)
* [`.claude/skills/codebase-intelligence/references/analysis-playbooks.md`](diffhunk://#diff-e96f4d2d7f3750606ccfef76395dcb1ddee2615c215da7fcc8ccb3adc95ba938L5-R5): Updated playbook instructions and agent automation commands to reference `oak-dev ci agent run` instead of `oak ci agent run`. [[1]](diffhunk://#diff-e96f4d2d7f3750606ccfef76395dcb1ddee2615c215da7fcc8ccb3adc95ba938L5-R5) [[2]](diffhunk://#diff-e96f4d2d7f3750606ccfef76395dcb1ddee2615c215da7fcc8ccb3adc95ba938L226-R229)
* [`.claude/skills/codebase-intelligence/references/finding-related-code.md`](diffhunk://#diff-7dff880bbc04423372ae6cd1d792cc39bc9d10ac1d7d7acc5921d7363289f6ffL32-R64): Changed all code search and context commands to use `oak-dev ci`, ensuring examples and workflow instructions are accurate for the development CLI. [[1]](diffhunk://#diff-7dff880bbc04423372ae6cd1d792cc39bc9d10ac1d7d7acc5921d7363289f6ffL32-R64) [[2]](diffhunk://#diff-7dff880bbc04423372ae6cd1d792cc39bc9d10ac1d7d7acc5921d7363289f6ffL73-R79) [[3]](diffhunk://#diff-7dff880bbc04423372ae6cd1d792cc39bc9d10ac1d7d7acc5921d7363289f6ffL95-R95) [[4]](diffhunk://#diff-7dff880bbc04423372ae6cd1d792cc39bc9d10ac1d7d7acc5921d7363289f6ffL104-R110) [[5]](diffhunk://#diff-7dff880bbc04423372ae6cd1d792cc39bc9d10ac1d7d7acc5921d7363289f6ffL123-R123) [[6]](diffhunk://#diff-7dff880bbc04423372ae6cd1d792cc39bc9d10ac1d7d7acc5921d7363289f6ffL134-R137)
* [`.claude/skills/codebase-intelligence/references/impact-analysis.md`](diffhunk://#diff-a49a601f06af3b72bfea8ee8cd90352311269cf922f9c4a9c9b7008ccf32e62bL25-R41): Updated semantic search, memory lookup, and impact analysis workflow steps to use `oak-dev ci` commands throughout. [[1]](diffhunk://#diff-a49a601f06af3b72bfea8ee8cd90352311269cf922f9c4a9c9b7008ccf32e62bL25-R41) [[2]](diffhunk://#diff-a49a601f06af3b72bfea8ee8cd90352311269cf922f9c4a9c9b7008ccf32e62bL50-R59) [[3]](diffhunk://#diff-a49a601f06af3b72bfea8ee8cd90352311269cf922f9c4a9c9b7008ccf32e62bL77-R95)

These updates unify the CLI references to the development version, reducing confusion and ensuring all documentation and configuration are aligned with the current tooling.

## Summary

Describe what changed and why.

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] CI/workflow update

## Scope

- [x] Installers (`install.sh`, `install.ps1`)
- [ ] CLI / pipeline commands
- [ ] Codebase Intelligence (daemon/activity/memory/search)
- [x] Agent integrations (hooks/MCP/skills)
- [ ] Templates / rules / strategic planning
- [ ] Packaging/release
- [ ] Docs

## Risk and Compatibility

- Risk level: [x] low [ ] medium [ ] high
- Backward compatibility impact:
- Migration or operator action required:

## Validation

List exactly what you ran and the result.

```bash
# Required
make check

# If installers were touched
pytest tests/test_install_scripts.py -v
```

## Checklist

- [ ] I read [CONTRIBUTING.md](CONTRIBUTING.md) and relevant project rules in `oak/constitution.md`
- [ ] `make check` passes locally
- [ ] I added or updated tests where behavior changed
- [ ] I updated docs for user-visible behavior/workflow changes
- [ ] I called out risks and compatibility impacts above
- [ ] I verified installer behavior if `install.sh` or `install.ps1` changed
