### PR TITLE
fix: always write daemon port to oak/daemon.port on init

### DIFF
--- a/.oak/config.yaml
+++ b/.oak/config.yaml
@@ -1,4 +1,4 @@
-version: 1.0.4.dev0+gdae04f6e3.d20260209
+version: 1.0.5.dev1+g666d8426b.d20260210
 agents:
 - copilot
 - opencode

--- a/src/open_agent_kit/features/codebase_intelligence/hooks/installer.py
+++ b/src/open_agent_kit/features/codebase_intelligence/hooks/installer.py
@@ -653,17 +653,26 @@ class HooksInstaller:
     def _get_daemon_port(self) -> int:
         """Get the daemon port for this project.
 
-        Uses the canonical get_project_port() which checks both the local
+        Uses the read-only read_project_port() which checks both the local
         override (.oak/ci/daemon.port) and the team-shared file
-        (oak/daemon.port), deriving a new port if neither exists.
+        (oak/daemon.port) without creating files as a side effect.
+
+        Falls back to get_project_port() only if no port file exists yet,
+        which can happen during initial setup before the daemon has started.
 
         Returns:
             The daemon port number.
         """
         from open_agent_kit.features.codebase_intelligence.daemon.manager import (
             get_project_port,
+            read_project_port,
         )
 
+        port = read_project_port(self.project_root)
+        if port is not None:
+            return port
+
+        logger.warning("No port file found; deriving port (daemon may not be running yet)")
         return get_project_port(self.project_root)
 
     def _install_otel_hooks(self) -> HooksInstallResult:


### PR DESCRIPTION
## Summary

This pull request refactors and improves the logic for resolving and managing the daemon port used by the codebase intelligence features. The major change is the introduction of a read-only `read_project_port()` function, which cleanly separates reading the port (without side effects) from assigning or creating it. The update also ensures that the canonical shared port file (`oak/daemon.port`) is always created and maintained, while local overrides remain machine-specific. Tests have been expanded to cover the new behaviors and edge cases.

**Port resolution and management improvements:**

* Added `read_project_port()` to read the daemon port from local override or shared files without creating or modifying any files, ensuring side-effect-free reads. Updated `get_project_port()` to always create the shared port file (`oak/daemon.port`) as the canonical source, while allowing local overrides for machine-specific conflicts.
* Removed the `_write_port` method from `DaemonManager` as port file management is now handled centrally, reducing duplication and side effects.

**Integration with other components:**

* Updated `_get_daemon_port()` methods in both the hooks and notifications installers to use the new `read_project_port()` for read-only access, falling back to `get_project_port()` only if no port file exists, ensuring correct and consistent port resolution. [[1]](diffhunk://#diff-31d1b8449e9b919e041c2c77e8e911fc6b6234e74c8b31ce4625736451bf3bedL654-R676) [[2]](diffhunk://#diff-39fad0f42697f74e084884f626bd8faf3424cf6c612b55f30f24589a4d08fc1fL69-R91)

**Testing enhancements:**

* Added comprehensive tests for `read_project_port()` to verify correct prioritization, handling of invalid or missing files, and absence of side effects. Expanded tests for `get_project_port()` to ensure the shared port file is always created and not overwritten unnecessarily, and that local overrides do not affect the shared file. [[1]](diffhunk://#diff-25fd60791403e39703f3c323e09259cbe07108f3ba7c0e5b6be68c233cd391faR109-R199) [[2]](diffhunk://#diff-25fd60791403e39703f3c323e09259cbe07108f3ba7c0e5b6be68c233cd391faL123-R236) [[3]](diffhunk://#diff-25fd60791403e39703f3c323e09259cbe07108f3ba7c0e5b6be68c233cd391faR286-R326)

**Version bump:**

* Incremented the version in `.oak/config.yaml` to reflect these changes.

## Related Issues

- Closes #
- Related #

## Change Type

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] CI/workflow update

## Scope

- [x] Installers (`install.sh`, `install.ps1`)
- [ ] CLI / pipeline commands
- [ ] Codebase Intelligence (daemon/activity/memory/search)
- [ ] Agent integrations (hooks/MCP/skills)
- [ ] Templates / rules / strategic planning
- [ ] Packaging/release
- [ ] Docs

## Risk and Compatibility

- Risk level: [ ] low [ ] medium [ ] high
- Backward compatibility impact:
- Migration or operator action required:

## Validation

List exactly what you ran and the result.

```bash
# Required
make check

# If installers were touched
pytest tests/test_install_scripts.py -v
```

## Checklist

- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and relevant project rules in `oak/constitution.md`
- [ ] `make check` passes locally
- [ ] I added or updated tests where behavior changed
- [ ] I updated docs for user-visible behavior/workflow changes
- [ ] I called out risks and compatibility impacts above
- [ ] I verified installer behavior if `install.sh` or `install.ps1` changed
