### PR TITLE
chore: align project sponsorship

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,1 @@
-# These are supported funding model platforms
-
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: sirkirby
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+github: goondocks-co


### PR DESCRIPTION
## What changed

- replaced the generated funding template with the Goondocks organization sponsor route

## Why

Open Agent Kit is a Goondocks-supported project, so its repository Sponsor button should route to the Goondocks GitHub Sponsors profile.

## Impact

The repository funding configuration now contains only `github: goondocks-co`. No application code or other repository metadata changed.

## Validation

- parsed `.github/FUNDING.yml` as YAML and verified the exact expected mapping
- ran `git diff --check`
- confirmed `.github/FUNDING.yml` is the only changed file
